### PR TITLE
Ever.add cliffterrain

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,5 +1,8 @@
 cmake_minimum_required(VERSION 3.10)
 
+# Turn on debugging symbols
+set(CMAKE_BUILD_TYPE Debug)
+
 # project name
 project(ArmyAntSim)
 
@@ -76,7 +79,7 @@ set_target_properties(Box2D PROPERTIES
     LIBRARY_OUTPUT_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR})
 
 # add executable
-add_executable(ArmyAntSim simulation/src/BoxTerrain.cpp simulation/src/Config.cpp simulation/src/Demo.cpp simulation/src/helpers.cpp simulation/src/main.cpp simulation/src/Ramp.cpp simulation/src/RobotController.cpp simulation/src/Robot.cpp simulation/src/Terrain.cpp simulation/src/V2BLTerrain.cpp simulation/src/VStepper.cpp simulation/src/Vterrain.cpp)
+add_executable(ArmyAntSim simulation/src/BoxTerrain.cpp simulation/src/Config.cpp simulation/src/Demo.cpp simulation/src/helpers.cpp simulation/src/main.cpp simulation/src/Ramp.cpp simulation/src/RobotController.cpp simulation/src/Robot.cpp simulation/src/Terrain.cpp simulation/src/V2BLTerrain.cpp simulation/src/VStepper.cpp simulation/src/Vterrain.cpp simulation/src/CliffTerrain.cpp)
 
 # link the Box2D library to the ArmyAntSim
 target_link_libraries(ArmyAntSim Box2D sfml-audio sfml-network sfml-window sfml-graphics sfml-system)

--- a/simulation/src/BoxTerrain.cpp
+++ b/simulation/src/BoxTerrain.cpp
@@ -1,5 +1,5 @@
 /*
- * World.cpp
+ * BoxTerrain.cpp
  *
  *  Created on: 27 sept. 2018
  *      Author: lucie

--- a/simulation/src/CliffTerrain.cpp
+++ b/simulation/src/CliffTerrain.cpp
@@ -12,8 +12,18 @@ CliffTerrain::CliffTerrain(){};
 CliffTerrain::CliffTerrain(b2World* world, sf::RenderWindow& window, config::sTerrain terrainParam, int WINDOW_X_PX, double bodyLength)
 : Terrain(world, window, terrainParam, WINDOW_X_PX, bodyLength){
 	// TODO Auto-generated constructor stub
-	m_M_TO_PX = WINDOW_X_PX /  (1.2*m_width);
-	m_posY=window.getSize().y/m_M_TO_PX - (window.getSize().y/m_M_TO_PX-m_height)/2;
+	m_M_TO_PX = WINDOW_X_PX /  25.0 * bodyLength;
+	std::cout << "window.getSize().y : " << window.getSize().y << std::endl;
+	std::cout << "m_M_TO_PX : " << m_M_TO_PX << std::endl;
+	std::cout << "window.getSize().y/m_M_TO_PX : " << window.getSize().y/m_M_TO_PX << std::endl;
+	std::cout << "m_height : " << m_height << std::endl;
+	std::cout << "(window.getSize().y/m_M_TO_PX-m_height) : " << (window.getSize().y/m_M_TO_PX-m_height) << std::endl;
+	std::cout << "(window.getSize().y/m_M_TO_PX-m_height)/2 : " << (window.getSize().y/m_M_TO_PX-m_height)/2 << std::endl;
+	std::cout << "window.getSize().y/m_M_TO_PX - (window.getSize().y/m_M_TO_PX-m_height)/2 : " << window.getSize().y/m_M_TO_PX - (window.getSize().y/m_M_TO_PX-m_height)/2 << std::endl;
+
+	// m_posY=window.getSize().y/m_M_TO_PX/2;
+	m_posY = 5 * bodyLength;
+	// m_posY=0.0;
 	m_window_x = window.getSize().x;
 	m_window_y = window.getSize().y;
 
@@ -25,9 +35,26 @@ CliffTerrain::~CliffTerrain() {
 
 void CliffTerrain::create(b2World* world, sf::RenderWindow& window, config::sTerrain terrainParam, int WINDOW_X_PX, double bodyLength){
 	Terrain::create(world, window, terrainParam, WINDOW_X_PX, bodyLength);
-	m_M_TO_PX = WINDOW_X_PX /  (1.2*m_width);
+
+	std::cout << "WINDOW_X_PX : " << WINDOW_X_PX << std::endl;
+	std::cout << "m_width : " << m_width << std::endl;
+
+	// m_M_TO_PX = WINDOW_X_PX /  (1.2*m_width);
+	m_M_TO_PX = WINDOW_X_PX /  25.0 * bodyLength;
 	printf("m_M_TO_PX: %f, \n", m_M_TO_PX);
-	m_posY=window.getSize().y/m_M_TO_PX - (window.getSize().y/m_M_TO_PX-m_height)/2;
+
+	std::cout << "window.getSize().y : " << window.getSize().y << std::endl;
+	std::cout << "m_M_TO_PX : " << m_M_TO_PX << std::endl;
+	std::cout << "window.getSize().y/m_M_TO_PX : " << window.getSize().y/m_M_TO_PX << std::endl;
+	std::cout << "m_height : " << m_height << std::endl;
+	std::cout << "(window.getSize().y/m_M_TO_PX-m_height) : " << (window.getSize().y/m_M_TO_PX-m_height) << std::endl;
+	std::cout << "(window.getSize().y/m_M_TO_PX-m_height)/2 : " << (window.getSize().y/m_M_TO_PX-m_height)/2 << std::endl;
+	std::cout << "window.getSize().y/m_M_TO_PX - (window.getSize().y/m_M_TO_PX-m_height)/2 : " << window.getSize().y/m_M_TO_PX - (window.getSize().y/m_M_TO_PX-m_height)/2 << std::endl;
+
+	// m_posY=window.getSize().y/m_M_TO_PX - (window.getSize().y/m_M_TO_PX-m_height)/2;
+	// m_posY=window.getSize().y/m_M_TO_PX/2;
+	m_posY = 5 * bodyLength;
+	// m_posY=0.0;
 	m_window_x = window.getSize().x;
 	m_window_y = window.getSize().y;
 }
@@ -43,6 +70,12 @@ void CliffTerrain::createBody(b2World* world){
 	float h = m_window_y/m_M_TO_PX-m_height;//window_y_px/m_to_pix - wall_h_m;
 	float l = m_window_x/m_M_TO_PX-m_width;//window_x_px/m_to_pix - wall_w_m;
 
+	// Questions:
+	// What does l represent?
+	// What does h represent?
+	// What does m_height represent?
+	// What does m_width represent?
+
 
 		// float h = window.getSize().y - m_height*m_M_TO_PX;
 	// float l = window.getSize().x - m_width*m_M_TO_PX;
@@ -55,30 +88,83 @@ void CliffTerrain::createBody(b2World* world){
 	// lines[4].position = sf::Vector2f(l/2, h/2);
 
 	// Define points for the rectangle frame
-	Point topLeftPoint = b2Vec2(l/2,h/2);
-	Point topRightPoint = b2Vec2(m_window_x/m_M_TO_PX - l/2,h/2);
-	Point bottomRightPoint = b2Vec2(m_window_x/m_M_TO_PX - l/2,m_window_y/m_M_TO_PX - h/2);
-	Point bottomLeftPoint = b2Vec2(l/2,m_window_y/m_M_TO_PX - h/2);
+	// Point topLeftPoint = b2Vec2(l/2,h/2);
+	// Point topRightPoint = b2Vec2(m_window_x/m_M_TO_PX - l/2,h/2);
+	// Point bottomRightPoint = b2Vec2(m_window_x/m_M_TO_PX - l/2,m_window_y/m_M_TO_PX - h/2);
+	// Point bottomLeftPoint = b2Vec2(l/2,m_window_y/m_M_TO_PX - h/2);
+	// Point arbitraryPoint = b2Vec2(1.0, 5.0);
 
-	// Create a closed rectangle polygon
-	Polygon rectanglePolygon{
-		topLeftPoint,
-		topRightPoint,
-		bottomRightPoint,
-		bottomLeftPoint,
-		topLeftPoint
+	// Point topLeftPoint = b2Vec2(l/2,h/2);
+	// Point topRightPoint = b2Vec2(m_window_x/m_M_TO_PX - l/2,h/2);
+
+
+	// Define all the points relevant to the cliff edges
+	// float cliffTop = m_window_y/m_M_TO_PX - h * 1.5;
+	float cliffTop = m_posY;
+	float cliffRightEdge = m_runaway;//10 * m_bodyLength;
+	float groundBottomEdge = m_posY + (6 * m_bodyLength);
+
+	Point cliffLeftPoint = b2Vec2(0.0, cliffTop);
+	Point cliffRightTopPoint = b2Vec2(cliffRightEdge, cliffTop);
+	Point cliffRightBottomPoint = b2Vec2(cliffRightEdge, groundBottomEdge);
+	Point cliffEndPoint = b2Vec2(m_window_x/m_M_TO_PX, groundBottomEdge);
+
+	// Point arbitraryPoint = b2Vec2(1.0, 5.0);
+
+	// Create the cliff polygon
+	Polygon cliffPolygon{
+		cliffLeftPoint,  // 0.66 | 4.49
+		cliffRightTopPoint, // 9.17 | 4.49
+		cliffRightBottomPoint,     // 0.65 | 0.92
+		cliffEndPoint,
+		// topRightPoint,    // 9.17 | 0.92
+		// // arbitraryPoint,   // 1.00 | 3.00
+		// topLeftPoint      // 0.66 | 0.92
 	};
 
-	// Create the Box2D edges for the rectangle
-	for (int ptcount = 0; ptcount < rectanglePolygon.size()-1; ptcount++) {
-		b2FixtureDef edgeFixtureDef;
-		edgeShape.Set(rectanglePolygon[ptcount], rectanglePolygon[ptcount+1]);
-		edgeFixtureDef.shape = &edgeShape;
-		m_groundBody->CreateFixture(&edgeFixtureDef);
+	// Add the cliff polygon to the vector of all the polygons
+	allPolygons.emplace_back(cliffPolygon);
+
+	// Define all the points relevant to the floating island
+	// float islandTop = m_window_y/m_M_TO_PX - h * 1.75;
+	// float islandBottom = m_window_y/m_M_TO_PX - h * 1.5;
+	// float islandRight = m_window_x/m_M_TO_PX - l * 1.0;
+	// float islandLeft = m_window_x/m_M_TO_PX - l * 3.0;
+
+	float islandTop = cliffTop;
+	float islandBottom = cliffTop + m_bodyLength;
+	float islandLeft = cliffRightEdge + 3 * m_bodyLength;
+	float islandRight = islandLeft + 4 * m_bodyLength;
+
+
+	Point islandLeftTopPoint = b2Vec2(islandLeft, islandTop);
+	Point islandRightTopPoint = b2Vec2(islandRight, islandTop);
+	Point islandRightBottomPoint = b2Vec2(islandRight, islandBottom);
+	Point islandLeftBottomPoint = b2Vec2(islandLeft, islandBottom);
+
+	// Create the island polygon
+	Polygon islandPolygon{
+		islandLeftTopPoint,
+		islandRightTopPoint,
+		islandRightBottomPoint,
+		islandLeftBottomPoint,
+		islandLeftTopPoint,
+	};
+
+	// Add the island polygon to the vector of all the polygons
+	allPolygons.emplace_back(islandPolygon);
+
+	// Create the Box2D edges for all the polygons
+	for (Polygon polygon : allPolygons) {
+		for (int ptcount = 0; ptcount < polygon.size()-1; ptcount++) {
+			b2FixtureDef edgeFixtureDef;
+			edgeShape.Set(polygon[ptcount], polygon[ptcount+1]);
+			edgeFixtureDef.shape = &edgeShape;
+			m_groundBody->CreateFixture(&edgeFixtureDef);
+		}
 	}
-	std::cout << "allPolygons.emplace_back()" << std::endl;
-	// Store the rectanglePolygon for rendering
-	allPolygons.emplace_back(rectanglePolygon);
+
+
 }
 
 void CliffTerrain::drawBody(sf::RenderWindow& window){
@@ -91,66 +177,16 @@ void CliffTerrain::drawBody(sf::RenderWindow& window){
 		sf::VertexArray lines(sf::LinesStrip, polygon.size());
 	// 	std::cout << "lines of size " << polygon.size() << std::endl;
 
-	// // 	// Populate lines with points from the polygon
-	// // 	std::cout << "for (int ptcount = 0; ptcount < polygon.size(); ptcount++) {" << std::endl;
+	    // Populate lines with points from the polygon
 		for (int ptcount = 0; ptcount < polygon.size(); ptcount++) {
-	// 		// std::cout << "lines[ptcount].position = sf::Vector2f(polygon[ptcount].x, polygon[ptcount].y);" << std::endl;
+			// Be sure to turn meter measurements from points to pixel measurements for rendering
 			lines[ptcount].position = sf::Vector2f(polygon[ptcount].x*m_M_TO_PX, polygon[ptcount].y*m_M_TO_PX);
 			lines[ptcount].color = sf::Color::Black;
-			std::cout << "Line " << ptcount << ": " << "x = " << polygon[ptcount].x << " | y = " << polygon[ptcount].y << std::endl;
+			// std::cout << "Line " << ptcount << ": " << "x = " << polygon[ptcount].x << " | y = " << polygon[ptcount].y << std::endl;
 		}
 
-	float h = window.getSize().y - m_height*m_M_TO_PX;
-	float l = window.getSize().x - m_width*m_M_TO_PX;
-
-	// sf::VertexArray lines(sf::LinesStrip, 5);
-	// lines[0].position = sf::Vector2f(l/2, h/2);
-	std::cout << "Line " << 0 << ": " << "x = " << l/2 << " | y = " << h/2 << std::endl;
-
-	// lines[1].position = sf::Vector2f(l/2, window.getSize().y-h/2);
-	std::cout << "Line " << 1 << ": " << "x = " << l/2 << " | y = " << window.getSize().y-h/2 << std::endl;
-
-	// lines[2].position = sf::Vector2f(window.getSize().x-l/2, window.getSize().y-h/2);
-	std::cout << "Line " << 2 << ": " << "x = " << window.getSize().x-l/2 << " | y = " << window.getSize().y-h/2 << std::endl;
-
-	// lines[3].position = sf::Vector2f(window.getSize().x-l/2, h/2);
-	std::cout << "Line " << 3 << ": " << "x = " << window.getSize().x-l/2 << " | y = " << h/2 << std::endl;
-
-	// lines[4].position = sf::Vector2f(l/2, h/2);
-	std::cout << "Line " << 4 << ": " << "x = " << l/2 << " | y = " << h/2 << std::endl;
-
-
-	// lines[0].color = sf::Color::Black;
-	// lines[1].color = sf::Color::Black;
-	// lines[2].color = sf::Color::Black;
-	// lines[3].color = sf::Color::Black;
-	// lines[4].color = sf::Color::Black;
-
-
-
-	// 	std::cout << "window.draw(lines);" << std::endl;
 		window.draw(lines);
 	}
-	std::cout << "Out of Polygon loop" << std::endl;
-
-	// float h = window.getSize().y - m_height*m_M_TO_PX;
-	// float l = window.getSize().x - m_width*m_M_TO_PX;
-
-	// sf::VertexArray lines(sf::LinesStrip, 5);
-	// lines[0].position = sf::Vector2f(l/2, h/2);
-	// lines[1].position = sf::Vector2f(l/2, window.getSize().y-h/2);
-	// lines[2].position = sf::Vector2f(window.getSize().x-l/2, window.getSize().y-h/2);
-	// lines[3].position = sf::Vector2f(window.getSize().x-l/2, h/2);
-	// lines[4].position = sf::Vector2f(l/2, h/2);
-
-	// lines[0].color = sf::Color::Black;
-	// lines[1].color = sf::Color::Black;
-	// lines[2].color = sf::Color::Black;
-	// lines[3].color = sf::Color::Black;
-	// lines[4].color = sf::Color::Black;
-
-	// window.draw(lines);
-
 }
 
 e_terrain_type CliffTerrain::getType(){

--- a/simulation/src/CliffTerrain.cpp
+++ b/simulation/src/CliffTerrain.cpp
@@ -1,0 +1,159 @@
+/*
+ * CliffTerrain.cpp
+ *
+ *  Created on: 6 feb. 2021
+ *      Author: ever
+ */
+
+#include "CliffTerrain.h"
+
+CliffTerrain::CliffTerrain(){};
+
+CliffTerrain::CliffTerrain(b2World* world, sf::RenderWindow& window, config::sTerrain terrainParam, int WINDOW_X_PX, double bodyLength)
+: Terrain(world, window, terrainParam, WINDOW_X_PX, bodyLength){
+	// TODO Auto-generated constructor stub
+	m_M_TO_PX = WINDOW_X_PX /  (1.2*m_width);
+	m_posY=window.getSize().y/m_M_TO_PX - (window.getSize().y/m_M_TO_PX-m_height)/2;
+	m_window_x = window.getSize().x;
+	m_window_y = window.getSize().y;
+
+}
+
+CliffTerrain::~CliffTerrain() {
+	// TODO Auto-generated destructor stub
+}
+
+void CliffTerrain::create(b2World* world, sf::RenderWindow& window, config::sTerrain terrainParam, int WINDOW_X_PX, double bodyLength){
+	Terrain::create(world, window, terrainParam, WINDOW_X_PX, bodyLength);
+	m_M_TO_PX = WINDOW_X_PX /  (1.2*m_width);
+	printf("m_M_TO_PX: %f, \n", m_M_TO_PX);
+	m_posY=window.getSize().y/m_M_TO_PX - (window.getSize().y/m_M_TO_PX-m_height)/2;
+	m_window_x = window.getSize().x;
+	m_window_y = window.getSize().y;
+}
+
+void CliffTerrain::createBody(b2World* world){
+
+    b2BodyDef BodyDef;
+    BodyDef.position = b2Vec2(0, 0);
+    BodyDef.type = b2_staticBody;
+    m_groundBody = world->CreateBody(&BodyDef);
+
+	b2EdgeShape edgeShape;
+	float h = m_window_y/m_M_TO_PX-m_height;//window_y_px/m_to_pix - wall_h_m;
+	float l = m_window_x/m_M_TO_PX-m_width;//window_x_px/m_to_pix - wall_w_m;
+
+
+		// float h = window.getSize().y - m_height*m_M_TO_PX;
+	// float l = window.getSize().x - m_width*m_M_TO_PX;
+
+	// sf::VertexArray lines(sf::LinesStrip, 5);
+	// lines[0].position = sf::Vector2f(l/2, h/2);
+	// lines[1].position = sf::Vector2f(l/2, window.getSize().y-h/2);
+	// lines[2].position = sf::Vector2f(window.getSize().x-l/2, window.getSize().y-h/2);
+	// lines[3].position = sf::Vector2f(window.getSize().x-l/2, h/2);
+	// lines[4].position = sf::Vector2f(l/2, h/2);
+
+	// Define points for the rectangle frame
+	Point topLeftPoint = b2Vec2(l/2,h/2);
+	Point topRightPoint = b2Vec2(m_window_x/m_M_TO_PX - l/2,h/2);
+	Point bottomRightPoint = b2Vec2(m_window_x/m_M_TO_PX - l/2,m_window_y/m_M_TO_PX - h/2);
+	Point bottomLeftPoint = b2Vec2(l/2,m_window_y/m_M_TO_PX - h/2);
+
+	// Create a closed rectangle polygon
+	Polygon rectanglePolygon{
+		topLeftPoint,
+		topRightPoint,
+		bottomRightPoint,
+		bottomLeftPoint,
+		topLeftPoint
+	};
+
+	// Create the Box2D edges for the rectangle
+	for (int ptcount = 0; ptcount < rectanglePolygon.size()-1; ptcount++) {
+		b2FixtureDef edgeFixtureDef;
+		edgeShape.Set(rectanglePolygon[ptcount], rectanglePolygon[ptcount+1]);
+		edgeFixtureDef.shape = &edgeShape;
+		m_groundBody->CreateFixture(&edgeFixtureDef);
+	}
+	std::cout << "allPolygons.emplace_back()" << std::endl;
+	// Store the rectanglePolygon for rendering
+	allPolygons.emplace_back(rectanglePolygon);
+}
+
+void CliffTerrain::drawBody(sf::RenderWindow& window){
+	// std::cout << "for (Polygon polygon : allPolygons) {" << std::endl;
+
+	for (Polygon polygon : allPolygons) {
+	// 	std::cout << "Polygon" << std::endl;
+	// // 	// Create our lines object
+	// // 	std::cout << "sf:: VertexArray lines(sf::LinesStrip, allPolygons.size());" << std::endl;
+		sf::VertexArray lines(sf::LinesStrip, polygon.size());
+	// 	std::cout << "lines of size " << polygon.size() << std::endl;
+
+	// // 	// Populate lines with points from the polygon
+	// // 	std::cout << "for (int ptcount = 0; ptcount < polygon.size(); ptcount++) {" << std::endl;
+		for (int ptcount = 0; ptcount < polygon.size(); ptcount++) {
+	// 		// std::cout << "lines[ptcount].position = sf::Vector2f(polygon[ptcount].x, polygon[ptcount].y);" << std::endl;
+			lines[ptcount].position = sf::Vector2f(polygon[ptcount].x*m_M_TO_PX, polygon[ptcount].y*m_M_TO_PX);
+			lines[ptcount].color = sf::Color::Black;
+			std::cout << "Line " << ptcount << ": " << "x = " << polygon[ptcount].x << " | y = " << polygon[ptcount].y << std::endl;
+		}
+
+	float h = window.getSize().y - m_height*m_M_TO_PX;
+	float l = window.getSize().x - m_width*m_M_TO_PX;
+
+	// sf::VertexArray lines(sf::LinesStrip, 5);
+	// lines[0].position = sf::Vector2f(l/2, h/2);
+	std::cout << "Line " << 0 << ": " << "x = " << l/2 << " | y = " << h/2 << std::endl;
+
+	// lines[1].position = sf::Vector2f(l/2, window.getSize().y-h/2);
+	std::cout << "Line " << 1 << ": " << "x = " << l/2 << " | y = " << window.getSize().y-h/2 << std::endl;
+
+	// lines[2].position = sf::Vector2f(window.getSize().x-l/2, window.getSize().y-h/2);
+	std::cout << "Line " << 2 << ": " << "x = " << window.getSize().x-l/2 << " | y = " << window.getSize().y-h/2 << std::endl;
+
+	// lines[3].position = sf::Vector2f(window.getSize().x-l/2, h/2);
+	std::cout << "Line " << 3 << ": " << "x = " << window.getSize().x-l/2 << " | y = " << h/2 << std::endl;
+
+	// lines[4].position = sf::Vector2f(l/2, h/2);
+	std::cout << "Line " << 4 << ": " << "x = " << l/2 << " | y = " << h/2 << std::endl;
+
+
+	// lines[0].color = sf::Color::Black;
+	// lines[1].color = sf::Color::Black;
+	// lines[2].color = sf::Color::Black;
+	// lines[3].color = sf::Color::Black;
+	// lines[4].color = sf::Color::Black;
+
+
+
+	// 	std::cout << "window.draw(lines);" << std::endl;
+		window.draw(lines);
+	}
+	std::cout << "Out of Polygon loop" << std::endl;
+
+	// float h = window.getSize().y - m_height*m_M_TO_PX;
+	// float l = window.getSize().x - m_width*m_M_TO_PX;
+
+	// sf::VertexArray lines(sf::LinesStrip, 5);
+	// lines[0].position = sf::Vector2f(l/2, h/2);
+	// lines[1].position = sf::Vector2f(l/2, window.getSize().y-h/2);
+	// lines[2].position = sf::Vector2f(window.getSize().x-l/2, window.getSize().y-h/2);
+	// lines[3].position = sf::Vector2f(window.getSize().x-l/2, h/2);
+	// lines[4].position = sf::Vector2f(l/2, h/2);
+
+	// lines[0].color = sf::Color::Black;
+	// lines[1].color = sf::Color::Black;
+	// lines[2].color = sf::Color::Black;
+	// lines[3].color = sf::Color::Black;
+	// lines[4].color = sf::Color::Black;
+
+	// window.draw(lines);
+
+}
+
+e_terrain_type CliffTerrain::getType(){
+	return CLIFF;
+}
+

--- a/simulation/src/CliffTerrain.h
+++ b/simulation/src/CliffTerrain.h
@@ -1,20 +1,32 @@
 /*
- * BoxTerrain.h
+ * CliffTerrain.h
  *
- *  Created on: 27 sept. 2018
- *      Author: lucie
+ *  Created on: 6 feb. 2021
+ *      Author: ever
  */
 
-#ifndef BOXTERRAIN_H_
-#define BOXTERRAIN_H_
+#ifndef CLIFFTERRAIN_H_
+#define CLIFFTERRAIN_H_
 
 #include "Terrain.h"
+#include <iostream>
 
-class BoxTerrain: public Terrain {
+// Point represents a point in 2D space on the simulation as a b2vec
+using Point = b2Vec2;
+
+// Polygon is a collection of points that form a polygon when connected
+// Like a "Connect the dots" puzzle where the dot coordinates are lined up
+// in order in a std::vector
+using Polygon = std::vector<Point>;
+
+// AllPolygons holds all the polygons on a particular terrain in no particular order
+using AllPolygons = std::vector<Polygon>;
+
+class CliffTerrain: public Terrain {
 public:
-	BoxTerrain();
-	BoxTerrain(	b2World* world, sf::RenderWindow& window, config::sTerrain terrainParam, int WINDOW_X_PX, double bodyLength=1);
-	virtual ~BoxTerrain();
+	CliffTerrain();
+	CliffTerrain(	b2World* world, sf::RenderWindow& window, config::sTerrain terrainParam, int WINDOW_X_PX, double bodyLength=1);
+	virtual ~CliffTerrain();
 
 	void create(b2World* world, sf::RenderWindow& window, config::sTerrain terrainParam, int WINDOW_X_PX, double bodyLength=1);
 
@@ -32,6 +44,7 @@ public:
 private:
 	int m_window_x=0;
 	int m_window_y=0;
+	AllPolygons allPolygons;
 };
 
-#endif /* BOXTERRAIN_H_ */
+#endif /* CLIFFTERRAIN_H_ */

--- a/simulation/src/Demo.cpp
+++ b/simulation/src/Demo.cpp
@@ -89,14 +89,27 @@ Demo::Demo(b2World* world, config::sConfig cfg){
 	if(distance_from_bottom){
 		float V_slope = m_terrain->getVLength()/2;
 		m_config.simulation.robot_initial_posX = m_terrain->getTopLeftCorner().x + V_slope - m_config.simulation.robot_initial_posX*m_config.robot.body_length;
+		std::cout << "V_slope x position" << std::endl;
 	}
 	else if(!(m_terrain->getType()==DEFAULT)){
+		// std::cout << "m_terrain->getTopLeftCorner().x | " << m_terrain->getTopLeftCorner().x << std::endl;
+		// std::cout << "m_config.simulation.robot_initial_posX | " << m_config.simulation.robot_initial_posX << std::endl;
+		// std::cout << "m_config.robot.body_length | " << m_config.robot.body_length << std::endl;
+
 		m_config.simulation.robot_initial_posX = m_terrain->getTopLeftCorner().x - m_config.simulation.robot_initial_posX*m_config.robot.body_length;
+		// std::cout << "m_config.simulation.robot_initial_posX | " << m_config.simulation.robot_initial_posX << std::endl;
+		// std::cout << "DEFAULT x position" << std::endl;
+	}
+	else
+	{
+		// std::cout << "Else x position" << std::endl;
 	}
 
 	/**Initial y position of the robot*/
 	m_config.robot.wheel_radius = (m_config.robot.body_length - 0.02)/4;
-	m_config.simulation.robot_initial_posY = m_terrain->getTopLeftCorner().y - m_config.robot.wheel_radius;
+	m_config.simulation.robot_initial_posY = m_terrain->getTopLeftCorner().y - m_config.robot.wheel_radius - m_config.simulation.robot_initial_posY * m_config.robot.body_length;
+
+	// TODO: Parse the -ry that is passed into the simulation
 
 	m_robotController.create(m_config.controller, m_config.robot, m_terrain->getBody());
 	m_robotController.setScale(m_to_px);

--- a/simulation/src/Demo.cpp
+++ b/simulation/src/Demo.cpp
@@ -67,6 +67,9 @@ Demo::Demo(b2World* world, config::sConfig cfg){
 	else if (m_config.terrain.type == "v_stepper") {
 		m_terrain = new VStepper;
 	}
+	else if (m_config.terrain.type == "cliff") {
+		m_terrain = new CliffTerrain;
+	}
 
 	// Vterrain m_terrain;
 	// this successfully changes the terrain type but for some reason it doesn't render properly

--- a/simulation/src/Demo.h
+++ b/simulation/src/Demo.h
@@ -23,6 +23,7 @@
 #include "V2BLTerrain.h"
 #include "Ramp.h"
 #include "VStepper.h"
+#include "CliffTerrain.h"
 #include <iostream>
 #include <fstream>
 #include "Config.h"

--- a/simulation/src/Demo.h
+++ b/simulation/src/Demo.h
@@ -151,19 +151,7 @@ private:
 //	b2Vec2 m_gravity = b2Vec2(0.f, 0.f);
 	RobotController m_robotController; //Robot controller containing the vector of the robots
 	double m_to_px; //Scale to do the conversion from real dimensions (m) to simulated ones (pixels). Usually obtained from the terrain
-	// BoxTerrain m_terrain; //Terrain used to do the simulation, the object can be changed to either: Terrain, BoxTerrain, Vterrain, V2BLTerrain, VStepper
-	// TODO: Make this terrain somehow templated or otherwise modular
-	// Vterrain m_terrain;
 	Terrain* m_terrain = new Terrain;
-	// maybe make this the Terrain type
-	//     and then make the terrain types use meta-programming instead of inheritance to switch between different terrain initializations
-	//     so there's all the terrain functions, and they each take in a type that you can specify when calling those methods
-	//     and that's where the meta-programming happens. It will call the function of that specific terrain type rather than a standard method
-	// could instead:
-	//    have a super class that is Terrain (as it is now)
-	//    and have the type used in the simulation be a Terrain type when it is declared
-	//    and have it be set equal to a specific terrain type when it's actually defined. And so long as the functions are all the same, then all should be fine.
-	//    This seems far easier and like it fits nicely with what already exists
 	MyContactListener_v2* myContactListener; //Contact listener
 	double m_it = 0; //Iteration counter used to create the robots with a given delay between them
 	int m_nbRobots = 0; //Number of robots created

--- a/simulation/src/Terrain.h
+++ b/simulation/src/Terrain.h
@@ -20,7 +20,7 @@
 /**@enum e_terrain_type
  * Different types of terrain used to do the simulation
  */
-enum e_terrain_type {DEFAULT, V_TERRAIN, V2BL_TERRAIN, RAMP, BOX, V_STEPPER};
+enum e_terrain_type {DEFAULT, V_TERRAIN, V2BL_TERRAIN, RAMP, BOX, V_STEPPER, CLIFF};
 
 class Terrain {
 public:

--- a/simulation/src/Vterrain.cpp
+++ b/simulation/src/Vterrain.cpp
@@ -24,6 +24,9 @@ Vterrain::~Vterrain() {
 
 void Vterrain::create(b2World* world, sf::RenderWindow& window, config::sTerrain terrainParam, int WINDOW_X_PX, double bodyLength){
 	Terrain::create(world, window, terrainParam, WINDOW_X_PX, bodyLength);
+	std::cout << "WINDOW_X_PX : " << WINDOW_X_PX << std::endl;
+	std::cout << "m_runaway : " << m_runaway << std::endl;
+	std::cout << "m_width : " << m_width << std::endl;
 	m_M_TO_PX = WINDOW_X_PX /  (2*m_runaway+m_width);
 	printf("m_M_TO_PX: %f, \n", m_M_TO_PX);
 }


### PR DESCRIPTION
- Added a cliff terrain as `CliffTerrain.h` and `CliffTerrain.cpp` that can be set by specifying `-y cliff`
- Created a new framework for creating terrains using `Polygon`s. This makes it so that all I have to do is create some polygons, define points for each polygon, and let the `CliffTerrain.cpp` script do the rest for creating the `Box2D` edges and rendering the polygons properly. See `CliffTerrain.cpp` or `CliffTerrain.h` for more details. The `Polygon` object is really just a `std::vector<b2Vec2>` object but more easily readable.
- The simulator is built quite well around using the `VTerrain`. To parametrize the cliff terrain, I basically use the same parameters that `VTerrain` uses to keep things from getting too complicated. Maybe later, it would make sense further modularize terrains so that each terrain has its own special configuration parameters, but right now the time sink isn't worth it.
- To control cliff parameters:
    - `-r` is a number of body lengths that defines the distance from the left edge of the window to the cliff edge
    - `-rx` defines in body lengths how far the Flippy will spawn from the edge of the cliff
    - `-ry` can be used to offset the initial y of the Flippy but isn't practically useful, other than dropping flippies from the sky if desired
- One liner for using the cliff terrain: `./build/ArmyAntSim -y cliff -g 9.8 -rx 8 -ry 0 -r 10`