### PR TITLE
Ever.torque

### DIFF
--- a/simulation/src/CliffTerrain.cpp
+++ b/simulation/src/CliffTerrain.cpp
@@ -5,6 +5,8 @@
  *      Author: ever
  */
 
+// goal position is (x,y)
+
 #include "CliffTerrain.h"
 
 CliffTerrain::CliffTerrain(){};
@@ -67,36 +69,6 @@ void CliffTerrain::createBody(b2World* world){
     m_groundBody = world->CreateBody(&BodyDef);
 
 	b2EdgeShape edgeShape;
-	float h = m_window_y/m_M_TO_PX-m_height;//window_y_px/m_to_pix - wall_h_m;
-	float l = m_window_x/m_M_TO_PX-m_width;//window_x_px/m_to_pix - wall_w_m;
-
-	// Questions:
-	// What does l represent?
-	// What does h represent?
-	// What does m_height represent?
-	// What does m_width represent?
-
-
-		// float h = window.getSize().y - m_height*m_M_TO_PX;
-	// float l = window.getSize().x - m_width*m_M_TO_PX;
-
-	// sf::VertexArray lines(sf::LinesStrip, 5);
-	// lines[0].position = sf::Vector2f(l/2, h/2);
-	// lines[1].position = sf::Vector2f(l/2, window.getSize().y-h/2);
-	// lines[2].position = sf::Vector2f(window.getSize().x-l/2, window.getSize().y-h/2);
-	// lines[3].position = sf::Vector2f(window.getSize().x-l/2, h/2);
-	// lines[4].position = sf::Vector2f(l/2, h/2);
-
-	// Define points for the rectangle frame
-	// Point topLeftPoint = b2Vec2(l/2,h/2);
-	// Point topRightPoint = b2Vec2(m_window_x/m_M_TO_PX - l/2,h/2);
-	// Point bottomRightPoint = b2Vec2(m_window_x/m_M_TO_PX - l/2,m_window_y/m_M_TO_PX - h/2);
-	// Point bottomLeftPoint = b2Vec2(l/2,m_window_y/m_M_TO_PX - h/2);
-	// Point arbitraryPoint = b2Vec2(1.0, 5.0);
-
-	// Point topLeftPoint = b2Vec2(l/2,h/2);
-	// Point topRightPoint = b2Vec2(m_window_x/m_M_TO_PX - l/2,h/2);
-
 
 	// Define all the points relevant to the cliff edges
 	// float cliffTop = m_window_y/m_M_TO_PX - h * 1.5;
@@ -133,9 +105,12 @@ void CliffTerrain::createBody(b2World* world){
 
 	float islandTop = cliffTop;
 	float islandBottom = cliffTop + m_bodyLength;
-	float islandLeft = cliffRightEdge + 3 * m_bodyLength;
-	float islandRight = islandLeft + 4 * m_bodyLength;
+	float islandLeft = cliffRightEdge + 6 * m_bodyLength;
+	// float islandRight = islandLeft + 4 * m_bodyLength;
+	float islandRight = m_window_x*m_M_TO_PX;
 
+	m_posGoal = b2Vec2(islandLeft, islandTop);
+	// std::cout << "CliffTerrain::createBody() " << m_posGoal.x << std::endl;
 
 	Point islandLeftTopPoint = b2Vec2(islandLeft, islandTop);
 	Point islandRightTopPoint = b2Vec2(islandRight, islandTop);

--- a/simulation/src/Config.h
+++ b/simulation/src/Config.h
@@ -69,6 +69,7 @@ struct sRobot{
 	double wheel_distance;
 	double attach_height;
 	double wheel_radius;
+	float torque;
 };
 
 struct sWindow{

--- a/simulation/src/Config.h
+++ b/simulation/src/Config.h
@@ -63,7 +63,9 @@ struct sController{
 
 struct sRobot{
 	double body_length;
+	int fixed_speed;
 	double speed;
+	double proportional_control;
 	double wheel_distance;
 	double attach_height;
 	double wheel_radius;

--- a/simulation/src/Demo.h
+++ b/simulation/src/Demo.h
@@ -189,6 +189,8 @@ private:
 	//	std::default_random_engine gen;
 	std::normal_distribution<double> m_gauss_delay;
 
+	std::string m_simulation_state = "Formation"; // Current state of the simulation (bridge formation vs bridge dissolution)
+
 protected:
 	b2World* m_world = nullptr; // pointer on the Box2D world
 };

--- a/simulation/src/Robot.cpp
+++ b/simulation/src/Robot.cpp
@@ -449,7 +449,8 @@ void Robot::moveBodyWithMotor(){
 		m_leftWheelMotor->EnableMotor(true);
 		m_leftWheelMotor->SetMotorSpeed(m_angularSpeed);
 		// TODO: Adjustable torque
-		m_leftWheelMotor->SetMaxMotorTorque(30.0f);
+		// m_leftWheelMotor->SetMaxMotorTorque(30.0f);
+		m_leftWheelMotor->SetMaxMotorTorque(m_robotParameters.torque);
 	}
 
 	else{
@@ -459,7 +460,8 @@ void Robot::moveBodyWithMotor(){
 		allowMotorRotation(RIGHT);
 		m_rightWheelMotor->EnableMotor(true);
 		m_rightWheelMotor->SetMotorSpeed(m_angularSpeed);
-		m_rightWheelMotor->SetMaxMotorTorque(30.0f);
+		// m_rightWheelMotor->SetMaxMotorTorque(30.0f);
+		m_leftWheelMotor->SetMaxMotorTorque(m_robotParameters.torque);
 	}
 
 //	m_shape3.setRadius(10);

--- a/simulation/src/Robot.cpp
+++ b/simulation/src/Robot.cpp
@@ -448,6 +448,7 @@ void Robot::moveBodyWithMotor(){
 		allowMotorRotation(LEFT);
 		m_leftWheelMotor->EnableMotor(true);
 		m_leftWheelMotor->SetMotorSpeed(m_angularSpeed);
+		// TODO: Adjustable torque
 		m_leftWheelMotor->SetMaxMotorTorque(30.0f);
 	}
 

--- a/simulation/src/RobotController.cpp
+++ b/simulation/src/RobotController.cpp
@@ -456,6 +456,9 @@ double RobotController::calculateSpeedsToGoal(b2Vec2 m_goal_pos, float Kp){
 			desired_speed = 0.1;
 		}
 
+		// Note: this is also triggered at the beginning of the simulation
+		// Consider just making the island higher up
+		// May not matter
 		float desired_y = m_goal_pos.y;
 		if(m_robotVector[i]->getPosition().y < desired_y){
 			desired_speed = m_robotParam.speed;

--- a/simulation/src/RobotController.cpp
+++ b/simulation/src/RobotController.cpp
@@ -433,6 +433,39 @@ double RobotController::getDissolutionTime(){
 	return m_dissolutionTime;
 }
 
+// Set speed for all robots
+void RobotController::SetGlobalSpeed(double desired_speed){
+	for (int i=0; i<m_robotVector.size(); i++){
+		m_robotVector[i]->setSpeed(desired_speed);
+	}
+}
+
+// float RobotController::calculateSpeed( robot, goal_pos )
+// or goal_pos could be an attribute of RobotController
+// and it's public and it's defined in config and set by Demo.cpp
+// also option for dynamic speed vs fixed speed in config
+// maybe change delay instead of speed (this is more portable for real robot)
+
+double RobotController::calculateSpeedsToGoal(b2Vec2 m_goal_pos, float Kp){
+	// Calculates the speed for every robot so that the robots move toward the desired goal
+	for (int i=0; i<m_robotVector.size(); i++){
+		float desired_x = m_goal_pos.x;
+		float error_x = desired_x - m_robotVector[i]->getPosition().x;
+		float desired_speed = 0.4 * log(error_x) + 2*PI;
+		if(isnan(desired_speed)){
+			desired_speed = 0.1;
+		}
+
+		float desired_y = m_goal_pos.y;
+		if(m_robotVector[i]->getPosition().y < desired_y){
+			desired_speed = m_robotParam.speed;
+		}
+
+		std::cout << desired_speed << std::endl;
+		m_robotVector[i]->setSpeed(desired_speed);
+	}
+}
+
 void RobotController::step(double end_x){
 
 	for (int i=0; i<m_robotVector.size(); i++){
@@ -531,7 +564,8 @@ bool RobotController::robotPushing(Robot& r){
 
 bool RobotController::robotStacking(Robot* r, float posX){
 	float x=r->getBody()->GetPosition().x;
-	if(x < (m_robotParam.body_length + posX)){
+	// if(x < (m_robotParam.body_length + posX)){
+	if(x<0.0){
 		return true;
 	}
 	return false;

--- a/simulation/src/RobotController.h
+++ b/simulation/src/RobotController.h
@@ -235,6 +235,13 @@ public:
 	 */
 	void wait_delay(Robot& robot);
 
+	void SetGlobalSpeed(double desired_speed);
+
+	/**
+	 *
+	*/
+	double calculateSpeedsToGoal(b2Vec2 m_goal_pos, float Kp);
+
 	/**
 	 * Flag used to notify when a new robot enter the bridge state.
 	 * It is used to write a new entry in the bridge file.

--- a/simulation/src/Terrain.h
+++ b/simulation/src/Terrain.h
@@ -8,6 +8,11 @@
  *  @author lucie houel
  */
 
+// Have it so that we set the goal position inside the terrain
+// Maybe even the terrain config so that it can be grabbed from
+// anywhere
+// have some way of redefining goal positions
+
 #ifndef TERRAIN_H_
 #define TERRAIN_H_
 
@@ -66,6 +71,9 @@ public:
 	/** @return the length of the V when it makes sense, 0 otherwise [m] */
 	double getVLength(){return 0;};
 
+	/** @return the position of the goal for the robots */
+	b2Vec2 getPosGoal(){return m_posGoal;};
+
 	/** @return a pointer on the Box2D body of the terrain*/
 	b2Body* getBody();
 
@@ -84,6 +92,7 @@ protected:
 	double m_runaway; //Runaway of the terrain. In the case of the default terrain the length of the ground is of 3*m_runaway (with the width of the window of 2*m_runaway)
 	double m_angle; //Angle of the obstacle in the terrain. In the case of the default terrain it doesn't make sense and is set to 0
 	double m_posY=2.5; //In the case of the default terrain it represents the distance from the top of the window/world to the ground.
+	b2Vec2 m_posGoal = b2Vec2(0.0,0.0); //Position of the goal for the robots
 
 	config::sTerrain m_terrainParam; //Terrain configuration parameters described in Config.h file
 };

--- a/simulation/src/main.cpp
+++ b/simulation/src/main.cpp
@@ -98,6 +98,7 @@ void default_parameters(config::sConfig& cfg){
 	cfg.robot.fixed_speed = true;
 	cfg.robot.speed = 2*PI; //Should not be changed
 	cfg.robot.proportional_control = 1.0;
+	cfg.robot.torque = 30.0f;
 
 	cfg.window.WINDOW_X_PX = 1920;
 	cfg.window.WINDOW_Y_PX = 1080;
@@ -202,6 +203,9 @@ void parse_argument(char* argv[], int i, config::sConfig& cfg){
 			}
 			else if (std::string(argv[i]) == "-kp" || std::string(argv[i]) == "--proportional_control") {
 				cfg.robot.speed = atof(argv[i + 1]);
+			}
+			else if (std::string(argv[i]) == "-tr" || std::string(argv[i]) == "--torque") {
+				cfg.robot.torque = atof(argv[i + 1]);
 			}
 
 			// Window parameters

--- a/simulation/src/main.cpp
+++ b/simulation/src/main.cpp
@@ -95,7 +95,9 @@ void default_parameters(config::sConfig& cfg){
 	cfg.controller.stability_condition = 60;
 
 	cfg.robot.body_length = 1.02;
+	cfg.robot.fixed_speed = true;
 	cfg.robot.speed = 2*PI; //Should not be changed
+	cfg.robot.proportional_control = 1.0;
 
 	cfg.window.WINDOW_X_PX = 1920;
 	cfg.window.WINDOW_Y_PX = 1080;
@@ -191,7 +193,14 @@ void parse_argument(char* argv[], int i, config::sConfig& cfg){
 				cfg.robot.body_length = atof(argv[i + 1]);
 				std::cout << cfg.robot.body_length << std::endl;
 			}
+			else if (std::string(argv[i]) == "-fs" || std::string(argv[i]) == "--fixed_speed") {
+				cfg.robot.fixed_speed = atof(argv[i+1]);
+				std::cout << "Robot Fixed Speed: " << cfg.robot.fixed_speed << std::endl;
+			}
 			else if (std::string(argv[i]) == "-v" || std::string(argv[i]) == "--robot_speed") {
+				cfg.robot.speed = atof(argv[i + 1]);
+			}
+			else if (std::string(argv[i]) == "-kp" || std::string(argv[i]) == "--proportional_control") {
 				cfg.robot.speed = atof(argv[i + 1]);
 			}
 


### PR DESCRIPTION
Features Added
- Can now set goal positions within a `terrain` class. This is used for dynamic speeds.
- Dynamic speed setting can now be turned on so that robots move at a dynamic speed towards the goal position of the `terrain` that they're in.
- Dynamic speed is based off a logarithmic function, where the input is the x distance from the goal, and the output is a scaled logarithmic output.
- Can switch from dynamic speed to fixed speed with `-fs`
- Stacking is redefined so that stacking is observed when a robot's position is all the way off the left edge of the simulation. (`x<0.0`)
- Torque is adjustable with `-tr`

Next Steps
- Can now input a `-kp` proportional control gain, but it isn't implemented anywhere. Implement it in the dynamic speed calculation so that the dynamic speed is tunable.
- Use the fixed speed as an offset in the dynamic speed calculation instead of using an arbitrary offset
- Replace manual command line parsing with a library like Tclap. This will make it much more convenient to add new command line arguments and edit current command line arguments without having to manually update so many things. Mostly, things like what the default argument is.
- The simulation state is stored as strings. Change that to an enum for the sake of robustness and readability.
- The simulation currently is split up into what to do if visualization is on, and what to do if visualization is off. Make sure that there's nothing going on differently under the hood. Consolidate these if possible.