### PR TITLE
Ever.tclap

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -3,6 +3,9 @@ cmake_minimum_required(VERSION 3.10)
 # Turn on debugging symbols
 set(CMAKE_BUILD_TYPE Debug)
 
+# Use C++17
+set(CMAKE_CXX_STANDARD 17)
+
 # project name
 project(ArmyAntSim)
 

--- a/lib/tclap/Arg.h
+++ b/lib/tclap/Arg.h
@@ -1,0 +1,603 @@
+// -*- Mode: c++; c-basic-offset: 4; tab-width: 4; -*-
+
+/******************************************************************************
+ *
+ *  file:  Arg.h
+ *
+ *  Copyright (c) 2003, Michael E. Smoot .
+ *  Copyright (c) 2004, Michael E. Smoot, Daniel Aarno .
+ *  Copyright (c) 2017 Google Inc.
+ *  All rights reserved.
+ *
+ *  See the file COPYING in the top directory of this distribution for
+ *  more information.
+ *
+ *  THE SOFTWARE IS PROVIDED _AS IS_, WITHOUT WARRANTY OF ANY KIND, EXPRESS
+ *  OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ *  FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL
+ *  THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ *  LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+ *  FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
+ *  DEALINGS IN THE SOFTWARE.
+ *
+ *****************************************************************************/
+
+#ifndef TCLAP_ARG_H
+#define TCLAP_ARG_H
+
+#ifdef HAVE_TCLAP_CONFIG_H
+#include <tclap/TCLAPConfig.h>
+#endif
+
+#include <tclap/ArgException.h>
+#include <tclap/ArgTraits.h>
+#include <tclap/CmdLineInterface.h>
+#include <tclap/StandardTraits.h>
+#include <tclap/Visitor.h>
+#include <tclap/sstream.h>
+
+#include <cstdio>
+#include <iomanip>
+#include <iostream>
+#include <list>
+#include <string>
+#include <vector>
+
+namespace TCLAP {
+
+/**
+ * A virtual base class that defines the essential data for all arguments.
+ * This class, or one of its existing children, must be subclassed to do
+ * anything.
+ */
+class Arg {
+private:
+    /**
+     * Prevent accidental copying.
+     */
+    Arg(const Arg &rhs);
+
+    /**
+     * Prevent accidental copying.
+     */
+    Arg &operator=(const Arg &rhs);
+
+    /**
+     * The delimiter that separates an argument flag/name from the
+     * value.
+     */
+    static char &delimiterRef() {
+        static char delim = ' ';
+        return delim;
+    }
+
+protected:
+    /**
+     * The single char flag used to identify the argument.
+     * This value (preceded by a dash {-}), can be used to identify
+     * an argument on the command line.  The _flag can be blank,
+     * in fact this is how unlabeled args work.  Unlabeled args must
+     * override appropriate functions to get correct handling. Note
+     * that the _flag does NOT include the dash as part of the flag.
+     */
+    std::string _flag;
+
+    /**
+     * A single word namd identifying the argument.
+     * This value (preceded by two dashed {--}) can also be used
+     * to identify an argument on the command line.  Note that the
+     * _name does NOT include the two dashes as part of the _name. The
+     * _name cannot be blank.
+     */
+    std::string _name;
+
+    /**
+     * Description of the argument.
+     */
+    std::string _description;
+
+    /**
+     * Indicating whether the argument is required.
+     */
+    const bool _required;
+
+    /**
+     * Label to be used in usage description.  Normally set to
+     * "required", but can be changed when necessary.
+     */
+    std::string _requireLabel;
+
+    /**
+     * Indicates whether a value is required for the argument.
+     * Note that the value may be required but the argument/value
+     * combination may not be, as specified by _required.
+     */
+    bool _valueRequired;
+
+    /**
+     * Indicates whether the argument has been set.
+     * Indicates that a value on the command line has matched the
+     * name/flag of this argument and the values have been set accordingly.
+     */
+    bool _alreadySet;
+
+    /** Indicates the value specified to set this flag (like -a or --all).
+     */
+    std::string _setBy;
+
+    /**
+     * A pointer to a visitor object.
+     * The visitor allows special handling to occur as soon as the
+     * argument is matched.  This defaults to NULL and should not
+     * be used unless absolutely necessary.
+     */
+    Visitor *_visitor;
+
+    /**
+     * Whether this argument can be ignored, if desired.
+     */
+    bool _ignoreable;
+
+    bool _acceptsMultipleValues;
+
+    /**
+     * Indicates if the argument is visible in the help output (e.g.,
+     * when specifying --help).
+     */
+    bool _visibleInHelp;
+
+    /**
+     * Performs the special handling described by the Visitor.
+     */
+    void _checkWithVisitor() const;
+
+    /**
+     * Primary constructor. YOU (yes you) should NEVER construct an Arg
+     * directly, this is a base class that is extended by various children
+     * that are meant to be used.  Use SwitchArg, ValueArg, MultiArg,
+     * UnlabeledValueArg, or UnlabeledMultiArg instead.
+     *
+     * \param flag - The flag identifying the argument.
+     * \param name - The name identifying the argument.
+     * \param desc - The description of the argument, used in the usage.
+     * \param req - Whether the argument is required.
+     * \param valreq - Whether the a value is required for the argument.
+     * \param v - The visitor checked by the argument. Defaults to NULL.
+     */
+    Arg(const std::string &flag, const std::string &name,
+        const std::string &desc, bool req, bool valreq, Visitor *v = NULL);
+
+public:
+    /**
+     * Destructor.
+     */
+    virtual ~Arg();
+
+    /**
+     * Adds this to the specified list of Args.
+     * \param argList - The list to add this to.
+     */
+    virtual void addToList(std::list<Arg *> &argList) const;
+
+    /**
+     * The delimiter that separates an argument flag/name from the
+     * value.
+     */
+    static char delimiter() { return delimiterRef(); }
+
+    /**
+     * The char used as a place holder when SwitchArgs are combined.
+     * Currently set to the bell char (ASCII 7).
+     */
+    static char blankChar() { return '\a'; }
+
+/**
+ * The char that indicates the beginning of a flag.  Defaults to '-', but
+ * clients can define TCLAP_FLAGSTARTCHAR to override.
+ */
+#ifndef TCLAP_FLAGSTARTCHAR
+#define TCLAP_FLAGSTARTCHAR '-'
+#endif
+    static char flagStartChar() { return TCLAP_FLAGSTARTCHAR; }
+
+/**
+ * The sting that indicates the beginning of a flag.  Defaults to "-", but
+ * clients can define TCLAP_FLAGSTARTSTRING to override. Should be the same
+ * as TCLAP_FLAGSTARTCHAR.
+ */
+#ifndef TCLAP_FLAGSTARTSTRING
+#define TCLAP_FLAGSTARTSTRING "-"
+#endif
+    static const std::string flagStartString() { return TCLAP_FLAGSTARTSTRING; }
+
+/**
+ * The sting that indicates the beginning of a name.  Defaults to "--", but
+ *  clients can define TCLAP_NAMESTARTSTRING to override.
+ */
+#ifndef TCLAP_NAMESTARTSTRING
+#define TCLAP_NAMESTARTSTRING "--"
+#endif
+    static const std::string nameStartString() { return TCLAP_NAMESTARTSTRING; }
+
+    /**
+     * The name used to identify the ignore rest argument.
+     */
+    static const std::string ignoreNameString() { return "ignore_rest"; }
+
+    /**
+     * Sets the delimiter for all arguments.
+     * \param c - The character that delimits flags/names from values.
+     */
+    static void setDelimiter(char c) { delimiterRef() = c; }
+
+    /**
+     * Pure virtual method meant to handle the parsing and value assignment
+     * of the string on the command line.
+     * \param i - Pointer the the current argument in the list.
+     * \param args - Mutable list of strings. What is
+     * passed in from main.
+     */
+    virtual bool processArg(int *i, std::vector<std::string> &args) = 0;
+
+    /**
+     * Operator ==.
+     * Equality operator. Must be virtual to handle unlabeled args.
+     * \param a - The Arg to be compared to this.
+     */
+    virtual bool operator==(const Arg &a) const;
+
+    /**
+     * Returns the argument flag.
+     */
+    const std::string &getFlag() const;
+
+    /**
+     * Returns the argument name.
+     */
+    const std::string &getName() const;
+
+    /**
+     * Returns the argument description.
+     */
+    std::string getDescription() const { return getDescription(_required); }
+
+    /**
+     * Returns the argument description.
+     *
+     * @param required if the argument should be treated as
+     * required when described.
+     */
+    std::string getDescription(bool required) const {
+        return (required ? "(" + _requireLabel + ") " : "") + _description;
+    }
+
+    /**
+     * Indicates whether the argument is required.
+     */
+    virtual bool isRequired() const;
+
+    /**
+     * Indicates whether a value must be specified for argument.
+     */
+    bool isValueRequired() const;
+
+    /**
+     * Indicates whether the argument has already been set.  Only true
+     * if the arg has been matched on the command line.
+     */
+    bool isSet() const;
+
+    /**
+     * Returns the value specified to set this flag (like -a or --all).
+     */
+    const std::string &setBy() const { return _setBy; }
+
+    /**
+     * Indicates whether the argument can be ignored, if desired.
+     */
+    bool isIgnoreable() const;
+
+    /**
+     * A method that tests whether a string matches this argument.
+     * This is generally called by the processArg() method.  This
+     * method could be re-implemented by a child to change how
+     * arguments are specified on the command line.
+     * \param s - The string to be compared to the flag/name to determine
+     * whether the arg matches.
+     */
+    virtual bool argMatches(const std::string &s) const;
+
+    /**
+     * Returns a simple string representation of the argument.
+     * Primarily for debugging.
+     */
+    virtual std::string toString() const;
+
+    /**
+     * Returns a short ID for the usage.
+     * \param valueId - The value used in the id.
+     */
+    virtual std::string shortID(const std::string &valueId = "val") const;
+
+    /**
+     * Returns a long ID for the usage.
+     * \param valueId - The value used in the id.
+     */
+    virtual std::string longID(const std::string &valueId = "val") const;
+
+    /**
+     * Trims a value off of the flag.
+     * \param flag - The string from which the flag and value will be
+     * trimmed. Contains the flag once the value has been trimmed.
+     * \param value - Where the value trimmed from the string will
+     * be stored.
+     */
+    virtual void trimFlag(std::string &flag, std::string &value) const;
+
+    /**
+     * Checks whether a given string has blank chars, indicating that
+     * it is a combined SwitchArg.  If so, return true, otherwise return
+     * false.
+     * \param s - string to be checked.
+     */
+    bool _hasBlanks(const std::string &s) const;
+
+    /**
+     * Used for MultiArgs to determine whether args can still be
+     * set.
+     */
+    virtual bool allowMore();
+
+    /**
+     * Use by output classes to determine whether an Arg accepts
+     * multiple values.
+     */
+    virtual bool acceptsMultipleValues();
+
+    /**
+     * Clears the Arg object and allows it to be reused by new
+     * command lines.
+     */
+    virtual void reset();
+
+    /**
+     * Hide this argument from the help output (e.g., when
+     * specifying the --help flag or on error.
+     */
+    virtual void hideFromHelp(bool hide = true) { _visibleInHelp = !hide; }
+
+    /**
+     * Returns true if this Arg is visible in the help output.
+     */
+    virtual bool visibleInHelp() const { return _visibleInHelp; }
+
+    virtual bool hasLabel() const { return true; }
+};
+
+/**
+ * Typedef of an Arg list iterator.
+ */
+typedef std::list<Arg *>::const_iterator ArgListIterator;
+
+/**
+ * Typedef of an Arg vector iterator.
+ */
+typedef std::vector<Arg *>::const_iterator ArgVectorIterator;
+
+/**
+ * Typedef of a Visitor list iterator.
+ */
+typedef std::list<Visitor *>::const_iterator VisitorListIterator;
+
+/*
+ * Extract a value of type T from it's string representation contained
+ * in strVal. The ValueLike parameter used to select the correct
+ * specialization of ExtractValue depending on the value traits of T.
+ * ValueLike traits use operator>> to assign the value from strVal.
+ */
+template <typename T>
+void ExtractValue(T &destVal, const std::string &strVal, ValueLike vl) {
+    static_cast<void>(vl);  // Avoid warning about unused vl
+    istringstream is(strVal.c_str());
+
+    int valuesRead = 0;
+    while (is.good()) {
+        if (is.peek() != EOF)
+#ifdef TCLAP_SETBASE_ZERO
+            is >> std::setbase(0) >> destVal;
+#else
+            is >> destVal;
+#endif
+        else
+            break;
+
+        valuesRead++;
+    }
+
+    if (is.fail())
+        throw(
+            ArgParseException("Couldn't read argument value "
+                              "from string '" +
+                              strVal + "'"));
+
+    if (valuesRead > 1)
+        throw(
+            ArgParseException("More than one valid value parsed from "
+                              "string '" +
+                              strVal + "'"));
+}
+
+/*
+ * Extract a value of type T from it's string representation contained
+ * in strVal. The ValueLike parameter used to select the correct
+ * specialization of ExtractValue depending on the value traits of T.
+ * StringLike uses assignment (operator=) to assign from strVal.
+ */
+template <typename T>
+void ExtractValue(T &destVal, const std::string &strVal, StringLike sl) {
+    static_cast<void>(sl);  // Avoid warning about unused sl
+    SetString(destVal, strVal);
+}
+
+//////////////////////////////////////////////////////////////////////
+// BEGIN Arg.cpp
+//////////////////////////////////////////////////////////////////////
+
+inline Arg::Arg(const std::string &flag, const std::string &name,
+                const std::string &desc, bool req, bool valreq, Visitor *v)
+    : _flag(flag),
+      _name(name),
+      _description(desc),
+      _required(req),
+      _requireLabel("required"),
+      _valueRequired(valreq),
+      _alreadySet(false),
+      _setBy(),
+      _visitor(v),
+      _ignoreable(true),
+      _acceptsMultipleValues(false),
+      _visibleInHelp(true) {
+    if (_flag.length() > 1)
+        throw(SpecificationException(
+            "Argument flag can only be one character long", toString()));
+
+    if (_name != ignoreNameString() &&
+        (_flag == Arg::flagStartString() || _flag == Arg::nameStartString() ||
+         _flag == " "))
+        throw(SpecificationException(
+            "Argument flag cannot be either '" + Arg::flagStartString() +
+                "' or '" + Arg::nameStartString() + "' or a space.",
+            toString()));
+
+    if ((_name.substr(0, Arg::flagStartString().length()) ==
+         Arg::flagStartString()) ||
+        (_name.substr(0, Arg::nameStartString().length()) ==
+         Arg::nameStartString()) ||
+        (_name.find(" ", 0) != std::string::npos))
+        throw(SpecificationException("Argument name begin with either '" +
+                                         Arg::flagStartString() + "' or '" +
+                                         Arg::nameStartString() + "' or space.",
+                                     toString()));
+}
+
+inline Arg::~Arg() {}
+
+inline std::string Arg::shortID(const std::string &valueId) const {
+    std::string id = "";
+
+    if (_flag != "")
+        id = Arg::flagStartString() + _flag;
+    else
+        id = Arg::nameStartString() + _name;
+
+    if (_valueRequired) id += std::string(1, Arg::delimiter()) + valueId;
+
+    return id;
+}
+
+inline std::string Arg::longID(const std::string &valueId) const {
+    std::string id = "";
+
+    if (_flag != "") {
+        id += Arg::flagStartString() + _flag;
+
+        if (_valueRequired) id += std::string(1, Arg::delimiter()) + valueId;
+
+        id += ",  ";
+    }
+
+    id += Arg::nameStartString() + _name;
+
+    if (_valueRequired) id += std::string(1, Arg::delimiter()) + valueId;
+
+    return id;
+}
+
+inline bool Arg::operator==(const Arg &a) const {
+    if ((_flag != "" && _flag == a._flag) || _name == a._name)
+        return true;
+    else
+        return false;
+}
+
+inline const std::string &Arg::getFlag() const { return _flag; }
+
+inline const std::string &Arg::getName() const { return _name; }
+
+inline bool Arg::isRequired() const { return _required; }
+
+inline bool Arg::isValueRequired() const { return _valueRequired; }
+
+inline bool Arg::isSet() const { return _alreadySet; }
+
+inline bool Arg::isIgnoreable() const { return _ignoreable; }
+
+inline bool Arg::argMatches(const std::string &argFlag) const {
+    if ((argFlag == Arg::flagStartString() + _flag && _flag != "") ||
+        argFlag == Arg::nameStartString() + _name)
+        return true;
+    else
+        return false;
+}
+
+inline std::string Arg::toString() const {
+    std::string s = "";
+
+    if (_flag != "") s += Arg::flagStartString() + _flag + " ";
+
+    s += "(" + Arg::nameStartString() + _name + ")";
+
+    return s;
+}
+
+inline void Arg::_checkWithVisitor() const {
+    if (_visitor != NULL) _visitor->visit();
+}
+
+/**
+ * Implementation of trimFlag.
+ */
+inline void Arg::trimFlag(std::string &flag, std::string &value) const {
+    int stop = 0;
+    for (int i = 0; static_cast<unsigned int>(i) < flag.length(); i++)
+        if (flag[i] == Arg::delimiter()) {
+            stop = i;
+            break;
+        }
+
+    if (stop > 1) {
+        value = flag.substr(stop + 1);
+        flag = flag.substr(0, stop);
+    }
+}
+
+/**
+ * Implementation of _hasBlanks.
+ */
+inline bool Arg::_hasBlanks(const std::string &s) const {
+    for (int i = 1; static_cast<unsigned int>(i) < s.length(); i++)
+        if (s[i] == Arg::blankChar()) return true;
+
+    return false;
+}
+
+/**
+ * Overridden by Args that need to added to the end of the list.
+ */
+inline void Arg::addToList(std::list<Arg *> &argList) const {
+    argList.push_front(const_cast<Arg *>(this));
+}
+
+inline bool Arg::allowMore() { return false; }
+
+inline bool Arg::acceptsMultipleValues() { return _acceptsMultipleValues; }
+
+inline void Arg::reset() { _alreadySet = false; }
+
+//////////////////////////////////////////////////////////////////////
+// END Arg.cpp
+//////////////////////////////////////////////////////////////////////
+
+}  // namespace TCLAP
+
+#endif  // TCLAP_ARG_H

--- a/lib/tclap/ArgContainer.h
+++ b/lib/tclap/ArgContainer.h
@@ -1,0 +1,58 @@
+// -*- Mode: c++; c-basic-offset: 4; tab-width: 4; -*-
+
+/******************************************************************************
+ *
+ *  file:  ArgContainer.h
+ *
+ *  Copyright (c) 2018 Google LLC
+ *  All rights reserved.
+ *
+ *  See the file COPYING in the top directory of this distribution for
+ *  more information.
+ *
+ *  THE SOFTWARE IS PROVIDED _AS IS_, WITHOUT WARRANTY OF ANY KIND, EXPRESS
+ *  OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ *  FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL
+ *  THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ *  LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+ *  FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
+ *  DEALINGS IN THE SOFTWARE.
+ *
+ *****************************************************************************/
+
+#ifndef TCLAP_ARG_CONTAINER_H
+#define TCLAP_ARG_CONTAINER_H
+
+namespace TCLAP {
+
+class Arg;
+
+/**
+ * Interface that allows adding an Arg to a "container".
+ *
+ * A container does not have to be a container in the C++ standard
+ * library sense, just something that wants to hold on to references
+ * to Arg's. The container does not own the added Arg's and it is the
+ * user's responsibility to ensure the life time (scope) of the Arg's
+ * outlives any operations on the container.
+ */
+class ArgContainer {
+public:
+    virtual ~ArgContainer() {}
+
+    /**
+     * Adds an argument. Ownership is not transfered.
+     * \param a - Argument to be added.
+     */
+    virtual ArgContainer &add(Arg &a) = 0;
+
+    /**
+     * Adds an argument. Ownership is not transfered.
+     * \param a - Argument to be added.
+     */
+    virtual ArgContainer &add(Arg *a) = 0;
+};
+
+}  // namespace TCLAP
+
+#endif  // TCLAP_ARG_CONTAINER_H

--- a/lib/tclap/ArgException.h
+++ b/lib/tclap/ArgException.h
@@ -1,0 +1,190 @@
+// -*- Mode: c++; c-basic-offset: 4; tab-width: 4; -*-
+
+/******************************************************************************
+ *
+ *  file:  ArgException.h
+ *
+ *  Copyright (c) 2003, Michael E. Smoot .
+ *  Copyright (c) 2017 Google LLC
+ *  All rights reserved.
+ *
+ *  See the file COPYING in the top directory of this distribution for
+ *  more information.
+ *
+ *  THE SOFTWARE IS PROVIDED _AS IS_, WITHOUT WARRANTY OF ANY KIND, EXPRESS
+ *  OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ *  FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL
+ *  THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ *  LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+ *  FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
+ *  DEALINGS IN THE SOFTWARE.
+ *
+ *****************************************************************************/
+
+#ifndef TCLAP_ARG_EXCEPTION_H
+#define TCLAP_ARG_EXCEPTION_H
+
+#include <exception>
+#include <string>
+
+namespace TCLAP {
+
+/**
+ * A simple class that defines and argument exception.  Should be caught
+ * whenever a CmdLine is created and parsed.
+ */
+class ArgException : public std::exception {
+public:
+    /**
+     * Constructor.
+     * \param text - The text of the exception.
+     * \param id - The text identifying the argument source.
+     * \param td - Text describing the type of ArgException it is.
+     * of the exception.
+     */
+    ArgException(const std::string &text = "undefined exception",
+                 const std::string &id = "undefined",
+                 const std::string &td = "Generic ArgException")
+        : std::exception(),
+          _errorText(text),
+          _argId(id),
+          _typeDescription(td) {}
+
+    /**
+     * Destructor.
+     */
+    virtual ~ArgException() throw() {}
+
+    /**
+     * Returns the error text.
+     */
+    std::string error() const { return (_errorText); }
+
+    /**
+     * Returns the argument id.
+     */
+    std::string argId() const {
+        if (_argId == "undefined")
+            return " ";
+        else
+            return ("Argument: " + _argId);
+    }
+
+    /**
+     * Returns the arg id and error text.
+     */
+    const char *what() const throw() {
+        static std::string ex;
+        ex = _argId + " -- " + _errorText;
+        return ex.c_str();
+    }
+
+    /**
+     * Returns the type of the exception.  Used to explain and distinguish
+     * between different child exceptions.
+     */
+    std::string typeDescription() const { return _typeDescription; }
+
+private:
+    /**
+     * The text of the exception message.
+     */
+    std::string _errorText;
+
+    /**
+     * The argument related to this exception.
+     */
+    std::string _argId;
+
+    /**
+     * Describes the type of the exception.  Used to distinguish
+     * between different child exceptions.
+     */
+    std::string _typeDescription;
+};
+
+/**
+ * Thrown from within the child Arg classes when it fails to properly
+ * parse the argument it has been passed.
+ */
+class ArgParseException : public ArgException {
+public:
+    /**
+     * Constructor.
+     * \param text - The text of the exception.
+     * \param id - The text identifying the argument source
+     * of the exception.
+     */
+    ArgParseException(const std::string &text = "undefined exception",
+                      const std::string &id = "undefined")
+        : ArgException(text, id,
+                       std::string("Exception found while parsing ") +
+                           std::string("the value the Arg has been passed.")) {}
+};
+
+/**
+ * Thrown from CmdLine when the arguments on the command line are not
+ * properly specified, e.g. too many arguments, required argument missing, etc.
+ */
+class CmdLineParseException : public ArgException {
+public:
+    /**
+     * Constructor.
+     * \param text - The text of the exception.
+     * \param id - The text identifying the argument source
+     * of the exception.
+     */
+    CmdLineParseException(const std::string &text = "undefined exception",
+                          const std::string &id = "undefined")
+        : ArgException(text, id,
+                       std::string("Exception found when the values ") +
+                           std::string("on the command line do not meet ") +
+                           std::string("the requirements of the defined ") +
+                           std::string("Args.")) {}
+};
+
+/**
+ * Thrown from Arg and CmdLine when an Arg is improperly specified, e.g.
+ * same flag as another Arg, same name, etc.
+ */
+class SpecificationException : public ArgException {
+public:
+    /**
+     * Constructor.
+     * \param text - The text of the exception.
+     * \param id - The text identifying the argument source
+     * of the exception.
+     */
+    SpecificationException(const std::string &text = "undefined exception",
+                           const std::string &id = "undefined")
+        : ArgException(text, id,
+                       std::string("Exception found when an Arg object ") +
+                           std::string("is improperly defined by the ") +
+                           std::string("developer.")) {}
+};
+
+/**
+ * Thrown when TCLAP thinks the program should exit.
+ *
+ * For example after parse error this exception will be thrown (and
+ * normally caught). This allows any resource to be clened properly
+ * before exit.
+ *
+ * If exception handling is disabled (CmdLine::setExceptionHandling),
+ * this exception will propagate to the call site, allowing the
+ * program to catch it and avoid program termination, or do it's own
+ * cleanup. See for example, https://sourceforge.net/p/tclap/bugs/29.
+ */
+class ExitException {
+public:
+    explicit ExitException(int estat) : _estat(estat) {}
+
+    int getExitStatus() const { return _estat; }
+
+private:
+    int _estat;
+};
+
+}  // namespace TCLAP
+
+#endif  // TCLAP_ARG_EXCEPTION_H

--- a/lib/tclap/ArgGroup.h
+++ b/lib/tclap/ArgGroup.h
@@ -1,0 +1,256 @@
+// -*- Mode: c++; c-basic-offset: 4; tab-width: 4; -*-
+
+/******************************************************************************
+ *
+ *  file:  ArgGroup.h
+ *
+ *  Copyright (c) 2017 Google LLC.
+ *  All rights reserved.
+ *
+ *  See the file COPYING in the top directory of this distribution for
+ *  more information.
+ *
+ *  THE SOFTWARE IS PROVIDED _AS IS_, WITHOUT WARRANTY OF ANY KIND, EXPRESS
+ *  OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ *  FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL
+ *  THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ *  LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+ *  FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
+ *  DEALINGS IN THE SOFTWARE.
+ *
+ *****************************************************************************/
+
+#ifndef TCLAP_ARG_GROUP_H
+#define TCLAP_ARG_GROUP_H
+
+#include <tclap/Arg.h>
+#include <tclap/ArgContainer.h>
+#include <tclap/CmdLineInterface.h>
+
+#include <list>
+#include <string>
+
+namespace TCLAP {
+
+/**
+ * ArgGroup is the base class for implementing groups of arguments
+ * that are mutually exclusive (it replaces the deprecated xor
+ * handler). It is not expected to be used directly, rather one of the
+ * EitherOf or OneOf derived classes are used.
+ */
+class ArgGroup : public ArgContainer {
+public:
+    typedef std::list<Arg *> Container;
+    typedef Container::iterator iterator;
+    typedef Container::const_iterator const_iterator;
+
+    virtual ~ArgGroup() {}
+
+    /// Add an argument to this arg group
+    virtual ArgContainer &add(Arg &arg) { return add(&arg); }
+
+    /// Add an argument to this arg group
+    virtual ArgContainer &add(Arg *arg);
+
+    /**
+     * Validates that the constraints of the ArgGroup are satisfied.
+     *
+     * @internal
+     * Throws an CmdLineParseException if there is an issue (except
+     * missing required argument, in which case true is returned).
+     *
+     * @retval true iff a required argument was missing.
+     */
+    virtual bool validate() = 0;
+
+    /**
+     * Returns true if this argument group is required
+     *
+     * @internal
+     */
+    virtual bool isRequired() const = 0;
+
+    /**
+     * Returns true if this argument group is exclusive.
+     *
+     * @internal
+     * Being exclusive means there is a constraint so that some
+     * arguments cannot be selected at the same time.
+     */
+    virtual bool isExclusive() const = 0;
+
+    /**
+     * Used by the parser to connect itself to this arg group.
+     *
+     * @internal
+     * This is needed so that existing and subsequently added args (in
+     * this arg group) are also added to the parser (and checked for
+     * consistency with other args).
+     */
+    void setParser(CmdLineInterface &parser) {
+        if (_parser) {
+            throw SpecificationException("Arg group can have only one parser");
+        }
+
+        _parser = &parser;
+        for (iterator it = begin(); it != end(); ++it) {
+            parser.addToArgList(*it);
+        }
+    }
+
+    /**
+     * If arguments in this group should show up as grouped in help.
+     */
+    virtual bool showAsGroup() const { return true; }
+
+    /// Returns the argument group's name.
+    const std::string getName() const;
+
+    iterator begin() { return _args.begin(); }
+    iterator end() { return _args.end(); }
+    const_iterator begin() const { return _args.begin(); }
+    const_iterator end() const { return _args.end(); }
+
+protected:
+    // No direct instantiation
+    ArgGroup() : _parser(0), _args() {}
+
+private:
+    explicit ArgGroup(const ArgGroup &);
+    ArgGroup &operator=(const ArgGroup &);  // no copy
+
+protected:
+    CmdLineInterface *_parser;
+    Container _args;
+};
+
+/**
+ * Implements common functionality for exclusive argument groups.
+ *
+ * @internal
+ */
+class ExclusiveArgGroup : public ArgGroup {
+public:
+    inline bool validate();
+    bool isExclusive() const { return true; }
+    ArgContainer &add(Arg &arg) { return add(&arg); }
+    ArgContainer &add(Arg *arg) {
+        if (arg->isRequired()) {
+            throw SpecificationException(
+                "Required arguments are not allowed"
+                " in an exclusive grouping.",
+                arg->longID());
+        }
+
+        return ArgGroup::add(arg);
+    }
+
+protected:
+    ExclusiveArgGroup() {}
+    explicit ExclusiveArgGroup(CmdLineInterface &parser) { parser.add(*this); }
+};
+
+/**
+ * Implements a group of arguments where at most one can be selected.
+ */
+class EitherOf : public ExclusiveArgGroup {
+public:
+    EitherOf() {}
+    explicit EitherOf(CmdLineInterface &parser) : ExclusiveArgGroup(parser) {}
+
+    bool isRequired() const { return false; }
+};
+
+/**
+ * Implements a group of arguments where exactly one must be
+ * selected. This corresponds to the deprecated "xoradd".
+ */
+class OneOf : public ExclusiveArgGroup {
+public:
+    OneOf() {}
+    explicit OneOf(CmdLineInterface &parser) : ExclusiveArgGroup(parser) {}
+
+    bool isRequired() const { return true; }
+};
+
+/**
+ * Implements a group of arguments where any combination is possible
+ * (including all or none). This is mostly used in case one optional
+ * argument allows additional arguments to be specified (for example
+ * [-c [-de] [-n <int>]]).
+ */
+class AnyOf : public ArgGroup {
+public:
+    AnyOf() {}
+    explicit AnyOf(CmdLineInterface &parser) { parser.add(*this); }
+
+    bool validate() { return false; /* All good */ }
+    bool isExclusive() const { return false; }
+    bool isRequired() const { return false; }
+};
+
+inline ArgContainer &ArgGroup::add(Arg *arg) {
+    for (iterator it = begin(); it != end(); it++) {
+        if (*arg == **it) {
+            throw SpecificationException(
+                "Argument with same flag/name already exists!", arg->longID());
+        }
+    }
+
+    _args.push_back(arg);
+    if (_parser) {
+        _parser->addToArgList(arg);
+    }
+
+    return *this;
+}
+
+inline bool ExclusiveArgGroup::validate() {
+    Arg *arg = NULL;
+    std::string flag;
+
+    for (const_iterator it = begin(); it != end(); ++it) {
+        if ((*it)->isSet()) {
+            if (arg != NULL && !(*arg == **it)) {
+                // We found a matching argument, but one was
+                // already found previously.
+                throw CmdLineParseException(
+                    "Only one is allowed.",
+                    flag + " AND " + (*it)->setBy() + " provided.");
+            }
+
+            arg = *it;
+            flag = arg->setBy();
+        }
+    }
+
+    return isRequired() && !arg;
+}
+
+inline const std::string ArgGroup::getName() const {
+    std::string name;
+    std::string sep = "{";  // TODO: this should change for
+                            // non-exclusive arg groups
+    for (const_iterator it = begin(); it != end(); ++it) {
+        name += sep + (*it)->getName();
+        sep = " | ";
+    }
+
+    return name + '}';
+}
+
+/// @internal
+inline int CountVisibleArgs(const ArgGroup &g) {
+    int visible = 0;
+    for (ArgGroup::const_iterator it = g.begin(); it != g.end(); ++it) {
+        if ((*it)->visibleInHelp()) {
+            visible++;
+        }
+    }
+
+    return visible;
+}
+
+}  // namespace TCLAP
+
+#endif  // TCLAP_ARG_GROUP_H

--- a/lib/tclap/ArgTraits.h
+++ b/lib/tclap/ArgTraits.h
@@ -1,0 +1,123 @@
+// -*- Mode: c++; c-basic-offset: 4; tab-width: 4; -*-
+
+/******************************************************************************
+ *
+ *  file:  ArgTraits.h
+ *
+ *  Copyright (c) 2007, Daniel Aarno, Michael E. Smoot .
+ *  Copyright (c) 2017 Google LLC
+ *  All rights reserved.
+ *
+ *  See the file COPYING in the top directory of this distribution for
+ *  more information.
+ *
+ *  THE SOFTWARE IS PROVIDED _AS IS_, WITHOUT WARRANTY OF ANY KIND, EXPRESS
+ *  OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ *  FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL
+ *  THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ *  LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+ *  FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
+ *  DEALINGS IN THE SOFTWARE.
+ *
+ *****************************************************************************/
+
+// This is an internal tclap file, you should probably not have to
+// include this directly
+
+#ifndef TCLAP_ARG_TRAITS_H
+#define TCLAP_ARG_TRAITS_H
+
+namespace TCLAP {
+
+// We use two empty structs to get compile type specialization
+// function to work
+
+/**
+ * A value like argument value type is a value that can be set using
+ * operator>>. This is the default value type.
+ */
+struct ValueLike {
+    typedef ValueLike ValueCategory;
+    virtual ~ValueLike() {}
+};
+
+/**
+ * A string like argument value type is a value that can be set using
+ * operator=(string). Useful if the value type contains spaces which
+ * will be broken up into individual tokens by operator>>.
+ */
+struct StringLike {
+    virtual ~StringLike() {}
+};
+
+/**
+ * A class can inherit from this object to make it have string like
+ * traits. This is a compile time thing and does not add any overhead
+ * to the inherenting class.
+ */
+struct StringLikeTrait {
+    typedef StringLike ValueCategory;
+    virtual ~StringLikeTrait() {}
+};
+
+/**
+ * A class can inherit from this object to make it have value like
+ * traits. This is a compile time thing and does not add any overhead
+ * to the inherenting class.
+ */
+struct ValueLikeTrait {
+    typedef ValueLike ValueCategory;
+    virtual ~ValueLikeTrait() {}
+};
+
+/**
+ * Arg traits are used to get compile type specialization when parsing
+ * argument values. Using an ArgTraits you can specify the way that
+ * values gets assigned to any particular type during parsing. The two
+ * supported types are StringLike and ValueLike. ValueLike is the
+ * default and means that operator>> will be used to assign values to
+ * the type.
+ */
+template <typename T>
+class ArgTraits {
+    // This is a bit silly, but what we want to do is:
+    // 1) If there exists a specialization of ArgTraits for type X,
+    // use it.
+    //
+    // 2) If no specialization exists but X has the typename
+    // X::ValueCategory, use the specialization for X::ValueCategory.
+    //
+    // 3) If neither (1) nor (2) defines the trait, use the default
+    // which is ValueLike.
+
+    // This is the "how":
+    //
+    // test<T>(0) (where 0 is the NULL ptr) will match
+    // test(typename C::ValueCategory*) iff type T has the
+    // corresponding typedef. If it does not test(...) will be
+    // matched. This allows us to determine if T::ValueCategory
+    // exists by checking the sizeof for the test function (return
+    // value must have different sizeof).
+    template <typename C>
+    static short test(typename C::ValueCategory *);  // NOLINT
+    template <typename C>
+    static long test(...);                                             // NOLINT
+    static const bool hasTrait = sizeof(test<T>(0)) == sizeof(short);  // NOLINT
+
+    template <typename C, bool>
+    struct DefaultArgTrait {
+        typedef ValueLike ValueCategory;
+    };
+
+    template <typename C>
+    struct DefaultArgTrait<C, true> {
+        typedef typename C::ValueCategory ValueCategory;
+    };
+
+public:
+    typedef typename DefaultArgTrait<T, hasTrait>::ValueCategory ValueCategory;
+};
+
+}  // namespace TCLAP
+
+#endif  // TCLAP_ARG_TRAITS_H

--- a/lib/tclap/CMakeLists.txt
+++ b/lib/tclap/CMakeLists.txt
@@ -1,0 +1,4 @@
+file(GLOB HEADER_FILES *.h)
+
+target_sources(TCLAP INTERFACE ${HEADER_FILES})
+install(FILES ${HEADER_FILES} DESTINATION include/tclap)

--- a/lib/tclap/CmdLine.h
+++ b/lib/tclap/CmdLine.h
@@ -1,0 +1,611 @@
+// -*- Mode: c++; c-basic-offset: 4; tab-width: 4; -*-
+
+/******************************************************************************
+ *
+ *  file:  CmdLine.h
+ *
+ *  Copyright (c) 2003, Michael E. Smoot .
+ *  Copyright (c) 2004, Michael E. Smoot, Daniel Aarno.
+ *  Copyright (c) 2018, Google LLC
+ *  All rights reserved.
+ *
+ *  See the file COPYING in the top directory of this distribution for
+ *  more information.
+ *
+ *  THE SOFTWARE IS PROVIDED _AS IS_, WITHOUT WARRANTY OF ANY KIND, EXPRESS
+ *  OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ *  FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL
+ *  THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ *  LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+ *  FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
+ *  DEALINGS IN THE SOFTWARE.
+ *
+ *****************************************************************************/
+
+#ifndef TCLAP_CMD_LINE_H
+#define TCLAP_CMD_LINE_H
+
+#include <tclap/MultiSwitchArg.h>
+#include <tclap/SwitchArg.h>
+#include <tclap/UnlabeledMultiArg.h>
+#include <tclap/UnlabeledValueArg.h>
+
+#include <tclap/HelpVisitor.h>
+#include <tclap/IgnoreRestVisitor.h>
+#include <tclap/VersionVisitor.h>
+
+#include <tclap/CmdLineOutput.h>
+#include <tclap/StdOutput.h>
+
+#include <tclap/Constraint.h>
+#include <tclap/ValuesConstraint.h>
+
+#include <tclap/ArgGroup.h>
+#include <tclap/DeferDelete.h>
+
+#include <algorithm>
+#include <cstdlib>
+#include <iomanip>
+#include <iostream>
+#include <list>
+#include <string>
+#include <vector>
+
+namespace TCLAP {
+
+class StandaloneArgs : public AnyOf {
+public:
+    StandaloneArgs() {}
+
+    ArgContainer &add(Arg *arg) {
+        // std::cerr << "Adding " << arg->getName() << " to StandaloneArgs\n";
+        for (iterator it = begin(); it != end(); it++) {
+            if (*arg == **it) {
+                throw SpecificationException(
+                    "Argument with same flag/name already exists!",
+                    arg->longID());
+            }
+        }
+
+        _args.push_back(arg);
+
+        return *this;
+    }
+
+    bool showAsGroup() const { return false; }
+};
+
+/**
+ * The base class that manages the command line definition and passes
+ * along the parsing to the appropriate Arg classes.
+ */
+class CmdLine : public CmdLineInterface {
+protected:
+    /**
+     * The list of arguments that will be tested against the
+     * command line.
+     */
+    std::list<Arg *> _argList;
+
+    StandaloneArgs _standaloneArgs;
+    StandaloneArgs _autoArgs;  // --help, --version, etc
+
+    /**
+     * Some args have set constraints on them (i.e., exactly or at
+     * most one must be specified.
+     */
+    std::list<ArgGroup *> _argGroups;
+
+    /**
+     * The name of the program.  Set to argv[0].
+     */
+    std::string _progName;
+
+    /**
+     * A message used to describe the program.  Used in the usage output.
+     */
+    std::string _message;
+
+    /**
+     * The version to be displayed with the --version switch.
+     */
+    std::string _version;
+
+    /**
+     * The number of arguments that are required to be present on
+     * the command line. This is set dynamically, based on the
+     * Args added to the CmdLine object.
+     */
+    int _numRequired;
+
+    /**
+     * The character that is used to separate the argument flag/name
+     * from the value.  Defaults to ' ' (space).
+     */
+    char _delimiter;
+
+    /**
+     * Add pointers that should be deleted as part of cleanup when
+     * this object is destroyed.
+     * @internal.
+     */
+    DeferDelete _deleteOnExit;
+
+    /**
+     * Default output handler if nothing is specified.
+     */
+    StdOutput _defaultOutput;
+
+    /**
+     * Object that handles all output for the CmdLine.
+     */
+    CmdLineOutput *_output;
+
+    /**
+     * Should CmdLine handle parsing exceptions internally?
+     */
+    bool _handleExceptions;
+
+    /**
+     * Throws an exception listing the missing args.
+     */
+    void missingArgsException(const std::list<ArgGroup *> &missing);
+
+    /**
+     * Checks whether a name/flag string matches entirely matches
+     * the Arg::blankChar.  Used when multiple switches are combined
+     * into a single argument.
+     * \param s - The message to be used in the usage.
+     */
+    bool _emptyCombined(const std::string &s);
+
+private:
+    /**
+     * Prevent accidental copying.
+     */
+    CmdLine(const CmdLine &rhs);
+    CmdLine &operator=(const CmdLine &rhs);
+
+    /**
+     * Encapsulates the code common to the constructors
+     * (which is all of it).
+     */
+    void _constructor();
+
+    /**
+     * Whether or not to automatically create help and version switches.
+     */
+    bool _helpAndVersion;
+
+    /**
+     * Whether or not to ignore unmatched args.
+     */
+    bool _ignoreUnmatched;
+
+    /**
+     * Ignoring arguments (e.g., after we have seen "--")
+     */
+    bool _ignoring;
+
+public:
+    /**
+     * Command line constructor. Defines how the arguments will be
+     * parsed.
+     * \param message - The message to be used in the usage
+     * output.
+     * \param delimiter - The character that is used to separate
+     * the argument flag/name from the value.  Defaults to ' ' (space).
+     * \param version - The version number to be used in the
+     * --version switch.
+     * \param helpAndVersion - Whether or not to create the Help and
+     * Version switches. Defaults to true.
+     */
+    CmdLine(const std::string &message, const char delimiter = ' ',
+            const std::string &version = "none", bool helpAndVersion = true);
+
+    /**
+     * Deletes any resources allocated by a CmdLine object.
+     */
+    virtual ~CmdLine() {}
+
+    /**
+     * Adds an argument to the list of arguments to be parsed.
+     *
+     * @param a - Argument to be added.
+     * @retval A reference to this so that add calls can be chained
+     */
+    ArgContainer &add(Arg &a);
+
+    /**
+     * An alternative add.  Functionally identical.
+     *
+     * @param a - Argument to be added.
+     * @retval A reference to this so that add calls can be chained
+     */
+    ArgContainer &add(Arg *a);
+
+    /**
+     * Adds an argument group to the list of arguments to be parsed.
+     *
+     * All arguments in the group are added and the ArgGroup
+     * object will validate that the input matches its
+     * constraints.
+     *
+     * @param args - Argument group to be added.
+     * @retval A reference to this so that add calls can be chained
+     */
+    ArgContainer &add(ArgGroup &args);
+
+    // Internal, do not use
+    void addToArgList(Arg *a);
+
+    /**
+     * \deprecated Use OneOf instead.
+     */
+    void xorAdd(Arg &a, Arg &b);
+
+    /**
+     * \deprecated Use OneOf instead.
+     */
+    void xorAdd(const std::vector<Arg *> &xors);
+
+    /**
+     * Parses the command line.
+     * \param argc - Number of arguments.
+     * \param argv - Array of arguments.
+     */
+    void parse(int argc, const char *const *argv);
+
+    /**
+     * Parses the command line.
+     * \param args - A vector of strings representing the args.
+     * args[0] is still the program name.
+     */
+    void parse(std::vector<std::string> &args);
+
+    void setOutput(CmdLineOutput *co);
+
+    std::string getVersion() const { return _version; }
+
+    std::string getProgramName() const { return _progName; }
+
+    // TOOD: Get rid of getArgList
+    std::list<Arg *> getArgList() const { return _argList; }
+    std::list<ArgGroup *> getArgGroups() {
+        std::list<ArgGroup *> groups = _argGroups;
+        groups.push_back(&_autoArgs);
+        return groups;
+    }
+
+    char getDelimiter() const { return _delimiter; }
+    std::string getMessage() const { return _message; }
+    bool hasHelpAndVersion() const { return _helpAndVersion; }
+
+    /**
+     * Disables or enables CmdLine's internal parsing exception handling.
+     *
+     * @param state Should CmdLine handle parsing exceptions internally?
+     */
+    void setExceptionHandling(const bool state);
+
+    /**
+     * Returns the current state of the internal exception handling.
+     *
+     * @retval true Parsing exceptions are handled internally.
+     * @retval false Parsing exceptions are propagated to the caller.
+     */
+    bool hasExceptionHandling() const { return _handleExceptions; }
+
+    /**
+     * Allows the CmdLine object to be reused.
+     */
+    void reset();
+
+    /**
+     * Allows unmatched args to be ignored. By default false.
+     *
+     * @param ignore If true the cmdline will ignore any unmatched args
+     * and if false it will behave as normal.
+     */
+    void ignoreUnmatched(const bool ignore);
+
+    void beginIgnoring() { _ignoring = true; }
+    bool ignoreRest() { return _ignoring; }
+};
+
+///////////////////////////////////////////////////////////////////////////////
+// Begin CmdLine.cpp
+///////////////////////////////////////////////////////////////////////////////
+
+inline CmdLine::CmdLine(const std::string &m, char delim, const std::string &v,
+                        bool help)
+    : _argList(),
+      _standaloneArgs(),
+      _autoArgs(),
+      _argGroups(),
+      _progName("not_set_yet"),
+      _message(m),
+      _version(v),
+      _numRequired(0),
+      _delimiter(delim),
+      _deleteOnExit(),
+      _defaultOutput(),
+      _output(&_defaultOutput),
+      _handleExceptions(true),
+      _helpAndVersion(help),
+      _ignoreUnmatched(false),
+      _ignoring(false) {
+    _constructor();
+}
+
+inline void CmdLine::_constructor() {
+    Arg::setDelimiter(_delimiter);
+
+    Visitor *v;
+    add(_standaloneArgs);
+    _autoArgs.setParser(*this);
+    // add(_autoArgs);
+
+    v = new IgnoreRestVisitor(*this);
+    SwitchArg *ignore = new SwitchArg(
+        Arg::flagStartString(), Arg::ignoreNameString(),
+        "Ignores the rest of the labeled arguments following this flag.", false,
+        v);
+    _deleteOnExit(ignore);
+    _deleteOnExit(v);
+    _autoArgs.add(ignore);
+    addToArgList(ignore);
+
+    if (_helpAndVersion) {
+        v = new HelpVisitor(this, &_output);
+        SwitchArg *help = new SwitchArg(
+            "h", "help", "Displays usage information and exits.", false, v);
+        _deleteOnExit(help);
+        _deleteOnExit(v);
+
+        v = new VersionVisitor(this, &_output);
+        SwitchArg *vers = new SwitchArg(
+            "", "version", "Displays version information and exits.", false, v);
+        _deleteOnExit(vers);
+        _deleteOnExit(v);
+
+        // A bit of a hack on the order to make tests easier to fix,
+        // to be reverted
+        _autoArgs.add(vers);
+        addToArgList(vers);
+        _autoArgs.add(help);
+        addToArgList(help);
+    }
+}
+
+inline void CmdLine::xorAdd(const std::vector<Arg *> &args) {
+    OneOf *group = new OneOf(*this);
+    _deleteOnExit(group);
+
+    for (std::vector<Arg *>::const_iterator it = args.begin(); it != args.end();
+         ++it) {
+        group->add(**it);
+    }
+}
+
+inline void CmdLine::xorAdd(Arg &a, Arg &b) {
+    std::vector<Arg *> ors;
+    ors.push_back(&a);
+    ors.push_back(&b);
+    xorAdd(ors);
+}
+
+inline ArgContainer &CmdLine::add(ArgGroup &args) {
+    args.setParser(*this);
+    _argGroups.push_back(&args);
+
+    return *this;
+}
+
+inline ArgContainer &CmdLine::add(Arg &a) { return add(&a); }
+
+// TODO: Rename this to something smarter or refactor this logic so
+// it's not needed.
+inline void CmdLine::addToArgList(Arg *a) {
+    for (ArgListIterator it = _argList.begin(); it != _argList.end(); it++)
+        if (*a == *(*it))
+            throw(SpecificationException(
+                "Argument with same flag/name already exists!", a->longID()));
+
+    a->addToList(_argList);
+
+    if (a->isRequired()) _numRequired++;
+}
+
+inline ArgContainer &CmdLine::add(Arg *a) {
+    addToArgList(a);
+    _standaloneArgs.add(a);
+
+    return *this;
+}
+
+inline void CmdLine::parse(int argc, const char *const *argv) {
+    // this step is necessary so that we have easy access to
+    // mutable strings.
+    std::vector<std::string> args;
+    for (int i = 0; i < argc; i++) args.push_back(argv[i]);
+
+    parse(args);
+}
+
+inline void CmdLine::parse(std::vector<std::string> &args) {
+    bool shouldExit = false;
+    int estat = 0;
+
+    try {
+        if (args.empty()) {
+            // https://sourceforge.net/p/tclap/bugs/30/
+            throw CmdLineParseException(
+                "The args vector must not be empty, "
+                "the first entry should contain the "
+                "program's name.");
+        }
+
+        // TODO(macbishop): Maybe store the full name somewhere?
+        _progName = basename(args.front());
+        args.erase(args.begin());
+
+        int requiredCount = 0;
+        std::list<ArgGroup *> missingArgGroups;
+
+        // Check that the right amount of arguments are provided for
+        // each ArgGroup, and if there are any required arguments
+        // missing, store them for later. Other errors will cause an
+        // exception to be thrown and parse will exit early.
+        /*
+        for (std::list<ArgGroup*>::iterator it = _argGroups.begin();
+             it != _argGroups.end(); ++it) {
+            bool missingRequired = (*it)->validate(args);
+            if (missingRequired) {
+                missingArgGroups.push_back(*it);
+            }
+        }
+        */
+
+        for (int i = 0; static_cast<unsigned int>(i) < args.size(); i++) {
+            bool matched = false;
+            for (ArgListIterator it = _argList.begin(); it != _argList.end();
+                 it++) {
+                Arg &arg = **it;
+                // We check if the argument was already set (e.g., for
+                // a Multi-Arg) since then we don't want to count it
+                // as required again. This is a hack/workaround to
+                // make isRequired() imutable so it can be used to
+                // display help correctly (also it's a good idea).
+                //
+                // TODO: This logic should probably be refactored to
+                // remove this logic from here.
+                bool alreadySet = arg.isSet();
+                bool ignore = arg.isIgnoreable() && ignoreRest();
+                if (!ignore && arg.processArg(&i, args)) {
+                    requiredCount += (!alreadySet && arg.isRequired()) ? 1 : 0;
+                    matched = true;
+                    break;
+                }
+            }
+
+            // checks to see if the argument is an empty combined
+            // switch and if so, then we've actually matched it
+            if (!matched && _emptyCombined(args[i])) matched = true;
+
+            if (!matched && !ignoreRest() && !_ignoreUnmatched)
+                throw(
+                    CmdLineParseException("Couldn't find match "
+                                          "for argument",
+                                          args[i]));
+        }
+
+        // Once all arguments have been parsed, check that we don't
+        // violate any constraints.
+        for (std::list<ArgGroup *>::iterator it = _argGroups.begin();
+             it != _argGroups.end(); ++it) {
+            bool missingRequired = (*it)->validate();
+            if (missingRequired) {
+                missingArgGroups.push_back(*it);
+            }
+        }
+
+        if (requiredCount < _numRequired || !missingArgGroups.empty()) {
+            missingArgsException(missingArgGroups);
+        }
+
+        if (requiredCount > _numRequired) {
+            throw(CmdLineParseException("Too many arguments!"));
+        }
+    } catch (ArgException &e) {
+        // If we're not handling the exceptions, rethrow.
+        if (!_handleExceptions) {
+            throw;
+        }
+
+        try {
+            _output->failure(*this, e);
+        } catch (ExitException &ee) {
+            estat = ee.getExitStatus();
+            shouldExit = true;
+        }
+    } catch (ExitException &ee) {
+        // If we're not handling the exceptions, rethrow.
+        if (!_handleExceptions) {
+            throw;
+        }
+
+        estat = ee.getExitStatus();
+        shouldExit = true;
+    }
+
+    if (shouldExit) exit(estat);
+}
+
+inline bool CmdLine::_emptyCombined(const std::string &s) {
+    if (s.length() > 0 && s[0] != Arg::flagStartChar()) return false;
+
+    for (int i = 1; static_cast<unsigned int>(i) < s.length(); i++)
+        if (s[i] != Arg::blankChar()) return false;
+
+    return true;
+}
+
+inline void CmdLine::missingArgsException(
+    const std::list<ArgGroup *> &missing) {
+    int count = 0;
+
+    std::string missingArgList;
+    for (ArgListIterator it = _argList.begin(); it != _argList.end(); it++) {
+        if ((*it)->isRequired() && !(*it)->isSet()) {
+            missingArgList += (*it)->getName();
+            missingArgList += ", ";
+            count++;
+        }
+    }
+
+    for (std::list<ArgGroup *>::const_iterator it = missing.begin();
+         it != missing.end(); it++) {
+        missingArgList += (*it)->getName();
+        missingArgList += ", ";
+        count++;
+    }
+
+    missingArgList = missingArgList.substr(0, missingArgList.length() - 2);
+
+    std::string msg;
+    if (count > 1)
+        msg = "Required arguments missing: ";
+    else
+        msg = "Required argument missing: ";
+
+    msg += missingArgList;
+
+    throw(CmdLineParseException(msg));
+}
+
+inline void CmdLine::setOutput(CmdLineOutput *co) { _output = co; }
+
+inline void CmdLine::setExceptionHandling(const bool state) {
+    _handleExceptions = state;
+}
+
+inline void CmdLine::reset() {
+    // TODO: This is no longer correct (or perhaps we don't need "reset")
+    for (ArgListIterator it = _argList.begin(); it != _argList.end(); it++)
+        (*it)->reset();
+
+    _progName.clear();
+}
+
+inline void CmdLine::ignoreUnmatched(const bool ignore) {
+    _ignoreUnmatched = ignore;
+}
+
+///////////////////////////////////////////////////////////////////////////////
+// End CmdLine.cpp
+///////////////////////////////////////////////////////////////////////////////
+
+}  // namespace TCLAP
+
+#endif  // TCLAP_CMD_LINE_H

--- a/lib/tclap/CmdLineInterface.h
+++ b/lib/tclap/CmdLineInterface.h
@@ -1,0 +1,166 @@
+// -*- Mode: c++; c-basic-offset: 4; tab-width: 4; -*-
+
+/******************************************************************************
+ *
+ *  file:  CmdLineInterface.h
+ *
+ *  Copyright (c) 2003, Michael E. Smoot .
+ *  Copyright (c) 2004, Michael E. Smoot, Daniel Aarno.
+ *  Copyright (c) 2017, Google LLC
+ *  All rights reserved.
+ *
+ *  See the file COPYING in the top directory of this distribution for
+ *  more information.
+ *
+ *  THE SOFTWARE IS PROVIDED _AS IS_, WITHOUT WARRANTY OF ANY KIND, EXPRESS
+ *  OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ *  FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL
+ *  THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ *  LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+ *  FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
+ *  DEALINGS IN THE SOFTWARE.
+ *
+ *****************************************************************************/
+
+#ifndef TCLAP_CMD_LINE_INTERFACE_H
+#define TCLAP_CMD_LINE_INTERFACE_H
+
+#include <tclap/ArgContainer.h>
+
+#include <algorithm>
+#include <iostream>
+#include <list>
+#include <string>
+#include <vector>
+
+namespace TCLAP {
+
+class Arg;
+class ArgGroup;
+class CmdLineOutput;
+
+/**
+ * The base class that manages the command line definition and passes
+ * along the parsing to the appropriate Arg classes.
+ */
+class CmdLineInterface : public ArgContainer {
+public:
+    /**
+     * Destructor
+     */
+    virtual ~CmdLineInterface() {}
+
+    /**
+     * Adds an argument. Ownership is not transfered.
+     * @param a - Argument to be added.
+     * @retval A reference to this so that add calls can be chained
+     */
+    virtual ArgContainer &add(Arg &a) = 0;
+
+    /**
+     * Adds an argument. Ownership is not transfered.
+     * @param a - Argument to be added.
+     * @retval A reference to this so that add calls can be chained
+     */
+    virtual ArgContainer &add(Arg *a) = 0;
+
+    // TODO: Rename this to something smarter or refactor this logic so
+    // it's not needed.
+    // Internal - do not use
+    virtual void addToArgList(Arg *a) = 0;
+
+    /**
+     * Adds an argument group to the list of arguments to be parsed.
+     *
+     * All arguments in the group are added and the ArgGroup
+     * object will validate that the input matches its
+     * constraints.
+     *
+     * @param args - Argument group to be added.
+     * @retval A reference to this so that add calls can be chained
+     */
+    virtual ArgContainer &add(ArgGroup &args) = 0;
+
+    /**
+     * \deprecated Use OneOf instead.
+     */
+    virtual void xorAdd(Arg &a, Arg &b) = 0;
+
+    /**
+     * \deprecated Use OneOf instead.
+     */
+    virtual void xorAdd(const std::vector<Arg *> &xors) = 0;
+
+    /**
+     * Parses the command line.
+     * \param argc - Number of arguments.
+     * \param argv - Array of arguments.
+     */
+    virtual void parse(int argc, const char *const *argv) = 0;
+
+    /**
+     * Parses the command line.
+     * \param args - A vector of strings representing the args.
+     * args[0] is still the program name.
+     */
+    void parse(std::vector<std::string> &args);
+
+    /**
+     * \param co - CmdLineOutput object that we want to use instead.
+     */
+    virtual void setOutput(CmdLineOutput *co) = 0;
+
+    /**
+     * Returns the version string.
+     */
+    virtual std::string getVersion() const = 0;
+
+    /**
+     * Returns the program name string.
+     */
+    virtual std::string getProgramName() const = 0;
+
+    /**
+     * Returns the list of ArgGroups.
+     */
+    virtual std::list<ArgGroup *> getArgGroups() = 0;
+    virtual std::list<Arg *> getArgList() const = 0;  // TODO: get rid of this
+
+    /**
+     * Returns the delimiter string.
+     */
+    virtual char getDelimiter() const = 0;
+
+    /**
+     * Returns the message string.
+     */
+    virtual std::string getMessage() const = 0;
+
+    /**
+     * Indicates whether or not the help and version switches were created
+     * automatically.
+     */
+    virtual bool hasHelpAndVersion() const = 0;
+
+    /**
+     * Resets the instance as if it had just been constructed so that the
+     * instance can be reused.
+     */
+    virtual void reset() = 0;
+
+    /**
+     * Begin ignoring arguments since the "--" argument was specified.
+     * \internal
+     */
+    virtual void beginIgnoring() = 0;
+
+    /**
+     * Whether to ignore the rest.
+     * \internal
+     */
+    virtual bool ignoreRest() = 0;
+};
+
+}  // namespace TCLAP
+
+#endif  // TCLAP_CMD_LINE_INTERFACE_H

--- a/lib/tclap/CmdLineOutput.h
+++ b/lib/tclap/CmdLineOutput.h
@@ -1,0 +1,111 @@
+// -*- Mode: c++; c-basic-offset: 4; tab-width: 4; -*-
+
+/******************************************************************************
+ *
+ *  file:  CmdLineOutput.h
+ *
+ *  Copyright (c) 2004, Michael E. Smoot
+ *  Copyright (c) 2017, Google LLC
+ *  All rights reserved.
+ *
+ *  See the file COPYING in the top directory of this distribution for
+ *  more information.
+ *
+ *  THE SOFTWARE IS PROVIDED _AS IS_, WITHOUT WARRANTY OF ANY KIND, EXPRESS
+ *  OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ *  FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL
+ *  THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ *  LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+ *  FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
+ *  DEALINGS IN THE SOFTWARE.
+ *
+ *****************************************************************************/
+
+#ifndef TCLAP_CMD_LINE_OUTPUT_H
+#define TCLAP_CMD_LINE_OUTPUT_H
+
+#include <tclap/Arg.h>
+#include <tclap/ArgGroup.h>
+
+#include <algorithm>
+#include <iomanip>
+#include <iostream>
+#include <list>
+#include <string>
+#include <vector>
+
+namespace TCLAP {
+
+class CmdLineInterface;
+class ArgException;
+
+/**
+ * The interface that any output object must implement.
+ */
+class CmdLineOutput {
+public:
+    /**
+     * Virtual destructor.
+     */
+    virtual ~CmdLineOutput() {}
+
+    /**
+     * Generates some sort of output for the USAGE.
+     * \param c - The CmdLine object the output is generated for.
+     */
+    virtual void usage(CmdLineInterface &c) = 0;
+
+    /**
+     * Generates some sort of output for the version.
+     * \param c - The CmdLine object the output is generated for.
+     */
+    virtual void version(CmdLineInterface &c) = 0;
+
+    /**
+     * Generates some sort of output for a failure.
+     * \param c - The CmdLine object the output is generated for.
+     * \param e - The ArgException that caused the failure.
+     */
+    virtual void failure(CmdLineInterface &c, ArgException &e) = 0;
+};
+
+inline bool isInArgGroup(const Arg *arg, const std::list<ArgGroup *> &argSets) {
+    for (std::list<ArgGroup *>::const_iterator it = argSets.begin();
+         it != argSets.end(); ++it) {
+        if (std::find((*it)->begin(), (*it)->end(), arg) != (*it)->end()) {
+            return true;
+        }
+    }
+    return false;
+}
+
+inline void removeArgsInArgGroups(std::list<Arg *> &argList,
+                                  const std::list<ArgGroup *> &argSets) {
+    for (std::list<Arg *>::iterator it = argList.begin();
+         it != argList.end();) {
+        if (isInArgGroup(*it, argSets)) {
+            it = argList.erase(it);
+        } else {
+            ++it;
+        }
+    }
+}
+
+inline std::string basename(std::string s) {
+    // TODO(macbishop): See if we can make this more robust
+    size_t p = s.find_last_of("/\\");
+    if (p != std::string::npos) {
+        s.erase(0, p + 1);
+    }
+
+    p = s.rfind(".exe");
+    if (p == s.length() - 4) {
+        s.erase(s.length() - 4);
+    }
+
+    return s;
+}
+
+}  // namespace TCLAP
+
+#endif  // TCLAP_CMD_LINE_OUTPUT_H

--- a/lib/tclap/Constraint.h
+++ b/lib/tclap/Constraint.h
@@ -1,0 +1,77 @@
+// -*- Mode: c++; c-basic-offset: 4; tab-width: 4; -*-
+
+/******************************************************************************
+ *
+ *  file:  Constraint.h
+ *
+ *  Copyright (c) 2005, Michael E. Smoot
+ *  Copyright (c) 2017, Google LLC
+ *  All rights reserved.
+ *
+ *  See the file COPYING in the top directory of this distribution for
+ *  more information.
+ *
+ *  THE SOFTWARE IS PROVIDED _AS IS_, WITHOUT WARRANTY OF ANY KIND, EXPRESS
+ *  OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ *  FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL
+ *  THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ *  LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+ *  FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
+ *  DEALINGS IN THE SOFTWARE.
+ *
+ *****************************************************************************/
+
+#ifndef TCLAP_CONSTRAINT_H
+#define TCLAP_CONSTRAINT_H
+
+#include <algorithm>
+#include <iomanip>
+#include <iostream>
+#include <list>
+#include <stdexcept>
+#include <string>
+#include <vector>
+
+namespace TCLAP {
+
+/**
+ * The interface that defines the interaction between the Arg and Constraint.
+ */
+template <class T>
+class Constraint {
+public:
+    /**
+     * Returns a description of the Constraint.
+     */
+    virtual std::string description() const = 0;
+
+    /**
+     * Returns the short ID for the Constraint.
+     */
+    virtual std::string shortID() const = 0;
+
+    /**
+     * The method used to verify that the value parsed from the command
+     * line meets the constraint.
+     * \param value - The value that will be checked.
+     */
+    virtual bool check(const T &value) const = 0;
+
+    /**
+     * Destructor.
+     * Silences warnings about Constraint being a base class with virtual
+     * functions but without a virtual destructor.
+     */
+    virtual ~Constraint() { ; }
+
+    static std::string shortID(Constraint<T> *constraint) {
+        if (!constraint)
+            throw std::logic_error(
+                "Cannot create a ValueArg with a NULL constraint");
+        return constraint->shortID();
+    }
+};
+
+}  // namespace TCLAP
+
+#endif  // TCLAP_CONSTRAINT_H

--- a/lib/tclap/DeferDelete.h
+++ b/lib/tclap/DeferDelete.h
@@ -1,0 +1,72 @@
+// -*- Mode: c++; c-basic-offset: 4; tab-width: 4; -*-
+
+/******************************************************************************
+ *
+ *  file:  DeferDelete.h
+ *
+ *  Copyright (c) 2020, Google LLC
+ *  All rights reserved.
+ *
+ *  See the file COPYING in the top directory of this distribution for
+ *  more information.
+ *
+ *  THE SOFTWARE IS PROVIDED _AS IS_, WITHOUT WARRANTY OF ANY KIND, EXPRESS
+ *  OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ *  FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL
+ *  THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ *  LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+ *  FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
+ *  DEALINGS IN THE SOFTWARE.
+ *
+ *****************************************************************************/
+
+#ifndef TCLAP_DEFER_DELETE_H
+#define TCLAP_DEFER_DELETE_H
+
+namespace TCLAP {
+
+/**
+ * DeferDelete can be used by objects that need to allocate arbitrary other
+ * objects to live for the duration of the first object. Any object
+ * added to DeferDelete (by calling operator()) will be deleted when
+ * the DeferDelete object is destroyed.
+ */
+class DeferDelete {
+    class DeletableBase {
+    public:
+        virtual ~DeletableBase() {}
+    };
+
+    template <typename T>
+    class Deletable : public DeletableBase {
+    public:
+        Deletable(T *o) : _o(o) {}
+        virtual ~Deletable() { delete _o; }
+
+    private:
+        Deletable(const Deletable<T> &) {}
+        Deletable<T> operator=(const Deletable<T> &) {}
+
+        T *_o;
+    };
+
+    std::list<DeletableBase *> _toBeDeleted;
+
+public:
+    DeferDelete() : _toBeDeleted() {}
+    ~DeferDelete() {
+        for (std::list<DeletableBase *>::iterator it = _toBeDeleted.begin();
+             it != _toBeDeleted.end(); ++it) {
+            delete *it;
+        }
+    }
+
+    template <typename T>
+    void operator()(T *toDelete) {
+        _toBeDeleted.push_back(new Deletable<T>(toDelete));
+    }
+};
+
+}  // namespace TCLAP
+
+#endif  // TCLAP_DEFER_DELETE_H

--- a/lib/tclap/DocBookOutput.h
+++ b/lib/tclap/DocBookOutput.h
@@ -1,0 +1,300 @@
+// -*- Mode: c++; c-basic-offset: 4; tab-width: 4; -*-
+
+/******************************************************************************
+ *
+ *  file:  DocBookOutput.h
+ *
+ *  Copyright (c) 2004, Michael E. Smoot
+ *  Copyright (c) 2017, Google LLC
+ *  All rights reserved.
+ *
+ *  See the file COPYING in the top directory of this distribution for
+ *  more information.
+ *
+ *  THE SOFTWARE IS PROVIDED _AS IS_, WITHOUT WARRANTY OF ANY KIND, EXPRESS
+ *  OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ *  FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL
+ *  THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ *  LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+ *  FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
+ *  DEALINGS IN THE SOFTWARE.
+ *
+ *****************************************************************************/
+
+#ifndef TCLAP_DOC_BOOK_OUTPUT_H
+#define TCLAP_DOC_BOOK_OUTPUT_H
+
+#include <tclap/Arg.h>
+#include <tclap/CmdLineInterface.h>
+#include <tclap/CmdLineOutput.h>
+
+#include <algorithm>
+#include <iostream>
+#include <list>
+#include <string>
+#include <vector>
+
+namespace TCLAP {
+
+/**
+ * A class that generates DocBook output for usage() method for the
+ * given CmdLine and its Args.
+ */
+class DocBookOutput : public CmdLineOutput {
+public:
+    /**
+     * Prints the usage to stdout.  Can be overridden to
+     * produce alternative behavior.
+     * \param c - The CmdLine object the output is generated for.
+     */
+    virtual void usage(CmdLineInterface &c);
+
+    /**
+     * Prints the version to stdout. Can be overridden
+     * to produce alternative behavior.
+     * \param c - The CmdLine object the output is generated for.
+     */
+    virtual void version(CmdLineInterface &c);
+
+    /**
+     * Prints (to stderr) an error message, short usage
+     * Can be overridden to produce alternative behavior.
+     * \param c - The CmdLine object the output is generated for.
+     * \param e - The ArgException that caused the failure.
+     */
+    virtual void failure(CmdLineInterface &c, ArgException &e);
+
+    DocBookOutput() : theDelimiter('=') {}
+
+protected:
+    /**
+     * Substitutes the char r for string x in string s.
+     * \param s - The string to operate on.
+     * \param r - The char to replace.
+     * \param x - What to replace r with.
+     */
+    void substituteSpecialChars(std::string &s, char r,
+                                const std::string &x) const;
+    void removeChar(std::string &s, char r) const;
+
+    void printShortArg(Arg *it, bool required);
+    void printLongArg(const ArgGroup &it) const;
+
+    char theDelimiter;
+};
+
+inline void DocBookOutput::version(CmdLineInterface &_cmd) {
+    std::cout << _cmd.getVersion() << std::endl;
+}
+
+namespace internal {
+const char *GroupChoice(const ArgGroup &group) {
+    if (!group.showAsGroup()) {
+        return "plain";
+    }
+
+    if (group.isRequired()) {
+        return "req";
+    }
+
+    return "opt";
+}
+}  // namespace internal
+
+inline void DocBookOutput::usage(CmdLineInterface &_cmd) {
+    std::list<ArgGroup *> argSets = _cmd.getArgGroups();
+    std::string progName = _cmd.getProgramName();
+    std::string xversion = _cmd.getVersion();
+    theDelimiter = _cmd.getDelimiter();
+
+    std::cout << "<?xml version='1.0'?>\n";
+    std::cout
+        << "<!DOCTYPE refentry PUBLIC \"-//OASIS//DTD DocBook XML V4.2//EN\"\n";
+    std::cout
+        << "\t\"http://www.oasis-open.org/docbook/xml/4.2/docbookx.dtd\">\n\n";
+
+    std::cout << "<refentry>\n";
+
+    std::cout << "<refmeta>\n";
+    std::cout << "<refentrytitle>" << progName << "</refentrytitle>\n";
+    std::cout << "<manvolnum>1</manvolnum>\n";
+    std::cout << "</refmeta>\n";
+
+    std::cout << "<refnamediv>\n";
+    std::cout << "<refname>" << progName << "</refname>\n";
+    std::cout << "<refpurpose>" << _cmd.getMessage() << "</refpurpose>\n";
+    std::cout << "</refnamediv>\n";
+
+    std::cout << "<refsynopsisdiv>\n";
+    std::cout << "<cmdsynopsis>\n";
+
+    std::cout << "<command>" << progName << "</command>\n";
+
+    for (std::list<ArgGroup *>::iterator sit = argSets.begin();
+         sit != argSets.end(); ++sit) {
+        int visible = CountVisibleArgs(**sit);
+        if (visible > 1) {
+            std::cout << "<group choice='" << internal::GroupChoice(**sit)
+                      << "'>\n";
+        }
+        for (ArgGroup::iterator it = (*sit)->begin(); it != (*sit)->end();
+             ++it) {
+            if (!(*it)->visibleInHelp()) {
+                continue;
+            }
+
+            printShortArg(*it, (*it)->isRequired() ||
+                                   (visible == 1 && (**sit).isRequired()));
+        }
+        if (visible > 1) {
+            std::cout << "</group>\n";
+        }
+    }
+
+    std::cout << "</cmdsynopsis>\n";
+    std::cout << "</refsynopsisdiv>\n";
+
+    std::cout << "<refsect1>\n";
+    std::cout << "<title>Description</title>\n";
+    std::cout << "<para>\n";
+    std::cout << _cmd.getMessage() << '\n';
+    std::cout << "</para>\n";
+    std::cout << "</refsect1>\n";
+
+    std::cout << "<refsect1>\n";
+    std::cout << "<title>Options</title>\n";
+
+    std::cout << "<variablelist>\n";
+
+    for (std::list<ArgGroup *>::iterator sit = argSets.begin();
+         sit != argSets.end(); ++sit) {
+        printLongArg(**sit);
+    }
+
+    std::cout << "</variablelist>\n";
+    std::cout << "</refsect1>\n";
+
+    std::cout << "<refsect1>\n";
+    std::cout << "<title>Version</title>\n";
+    std::cout << "<para>\n";
+    std::cout << xversion << '\n';
+    std::cout << "</para>\n";
+    std::cout << "</refsect1>\n";
+
+    std::cout << "</refentry>" << std::endl;
+}
+
+inline void DocBookOutput::failure(CmdLineInterface &_cmd, ArgException &e) {
+    static_cast<void>(_cmd);  // unused
+    std::cout << e.what() << std::endl;
+    throw ExitException(1);
+}
+
+inline void DocBookOutput::substituteSpecialChars(std::string &s, char r,
+                                                  const std::string &x) const {
+    size_t p;
+    while ((p = s.find_first_of(r)) != std::string::npos) {
+        s.erase(p, 1);
+        s.insert(p, x);
+    }
+}
+
+inline void DocBookOutput::removeChar(std::string &s, char r) const {
+    size_t p;
+    while ((p = s.find_first_of(r)) != std::string::npos) {
+        s.erase(p, 1);
+    }
+}
+
+inline void DocBookOutput::printShortArg(Arg *a, bool required) {
+    std::string lt = "&lt;";
+    std::string gt = "&gt;";
+
+    std::string id = a->shortID();
+    substituteSpecialChars(id, '<', lt);
+    substituteSpecialChars(id, '>', gt);
+    removeChar(id, '[');
+    removeChar(id, ']');
+
+    std::string choice = "opt";
+    if (required) {
+        choice = "plain";
+    }
+
+    std::cout << "<arg choice='" << choice << '\'';
+    if (a->acceptsMultipleValues()) std::cout << " rep='repeat'";
+
+    std::cout << '>';
+    if (!a->getFlag().empty())
+        std::cout << a->flagStartChar() << a->getFlag();
+    else
+        std::cout << a->nameStartString() << a->getName();
+    if (a->isValueRequired()) {
+        std::string arg = a->shortID();
+        removeChar(arg, '[');
+        removeChar(arg, ']');
+        removeChar(arg, '<');
+        removeChar(arg, '>');
+        removeChar(arg, '.');
+        arg.erase(0, arg.find_last_of(theDelimiter) + 1);
+        std::cout << theDelimiter;
+        std::cout << "<replaceable>" << arg << "</replaceable>";
+    }
+    std::cout << "</arg>" << std::endl;
+}
+
+inline void DocBookOutput::printLongArg(const ArgGroup &group) const {
+    const std::string lt = "&lt;";
+    const std::string gt = "&gt;";
+
+    bool forceRequired = group.isRequired() && CountVisibleArgs(group) == 1;
+    for (ArgGroup::const_iterator it = group.begin(); it != group.end(); ++it) {
+        Arg &a = **it;
+        if (!a.visibleInHelp()) {
+            continue;
+        }
+
+        std::string desc = a.getDescription(forceRequired || a.isRequired());
+        substituteSpecialChars(desc, '<', lt);
+        substituteSpecialChars(desc, '>', gt);
+
+        std::cout << "<varlistentry>\n";
+
+        if (!a.getFlag().empty()) {
+            std::cout << "<term>\n";
+            std::cout << "<option>";
+            std::cout << a.flagStartChar() << a.getFlag();
+            std::cout << "</option>\n";
+            std::cout << "</term>\n";
+        }
+
+        std::cout << "<term>\n";
+        std::cout << "<option>";
+        std::cout << a.nameStartString() << a.getName();
+        if (a.isValueRequired()) {
+            std::string arg = a.shortID();
+            removeChar(arg, '[');
+            removeChar(arg, ']');
+            removeChar(arg, '<');
+            removeChar(arg, '>');
+            removeChar(arg, '.');
+            arg.erase(0, arg.find_last_of(theDelimiter) + 1);
+            std::cout << theDelimiter;
+            std::cout << "<replaceable>" << arg << "</replaceable>";
+        }
+
+        std::cout << "</option>\n";
+        std::cout << "</term>\n";
+
+        std::cout << "<listitem>\n";
+        std::cout << "<para>\n";
+        std::cout << desc << '\n';
+        std::cout << "</para>\n";
+        std::cout << "</listitem>\n";
+
+        std::cout << "</varlistentry>" << std::endl;
+    }
+}
+
+}  // namespace TCLAP
+#endif  // TCLAP_DOC_BOOK_OUTPUT_H

--- a/lib/tclap/HelpVisitor.h
+++ b/lib/tclap/HelpVisitor.h
@@ -1,0 +1,75 @@
+// -*- Mode: c++; c-basic-offset: 4; tab-width: 4; -*-
+
+/******************************************************************************
+ *
+ *  file:  HelpVisitor.h
+ *
+ *  Copyright (c) 2003, Michael E. Smoot .
+ *  All rights reserved.
+ *
+ *  See the file COPYING in the top directory of this distribution for
+ *  more information.
+ *
+ *  THE SOFTWARE IS PROVIDED _AS IS_, WITHOUT WARRANTY OF ANY KIND, EXPRESS
+ *  OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ *  FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL
+ *  THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ *  LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+ *  FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
+ *  DEALINGS IN THE SOFTWARE.
+ *
+ *****************************************************************************/
+
+#ifndef TCLAP_HELP_VISITOR_H
+#define TCLAP_HELP_VISITOR_H
+
+#include <tclap/CmdLineInterface.h>
+#include <tclap/CmdLineOutput.h>
+#include <tclap/Visitor.h>
+
+namespace TCLAP {
+
+/**
+ * A Visitor object that calls the usage method of the given CmdLineOutput
+ * object for the specified CmdLine object.
+ */
+class HelpVisitor : public Visitor {
+private:
+    /**
+     * Prevent accidental copying.
+     */
+    HelpVisitor(const HelpVisitor &rhs);
+    HelpVisitor &operator=(const HelpVisitor &rhs);
+
+protected:
+    /**
+     * The CmdLine the output will be generated for.
+     */
+    CmdLineInterface *_cmd;
+
+    /**
+     * The output object.
+     */
+    CmdLineOutput **_out;
+
+public:
+    /**
+     * Constructor.
+     * \param cmd - The CmdLine the output will be generated for.
+     * \param out - The type of output.
+     */
+    HelpVisitor(CmdLineInterface *cmd, CmdLineOutput **out)
+        : Visitor(), _cmd(cmd), _out(out) {}
+
+    /**
+     * Calls the usage method of the CmdLineOutput for the
+     * specified CmdLine.
+     */
+    void visit() {
+        (*_out)->usage(*_cmd);
+        throw ExitException(0);
+    }
+};
+}  // namespace TCLAP
+
+#endif  // TCLAP_HELP_VISITOR_H

--- a/lib/tclap/IgnoreRestVisitor.h
+++ b/lib/tclap/IgnoreRestVisitor.h
@@ -1,0 +1,47 @@
+// -*- Mode: c++; c-basic-offset: 4; tab-width: 4; -*-
+
+/******************************************************************************
+ *
+ *  file:  IgnoreRestVisitor.h
+ *
+ *  Copyright (c) 2003, Michael E. Smoot .
+ *  Copyright (c) 2020, Google LLC
+ *  All rights reserved.
+ *
+ *  See the file COPYING in the top directory of this distribution for
+ *  more information.
+ *
+ *  THE SOFTWARE IS PROVIDED _AS IS_, WITHOUT WARRANTY OF ANY KIND, EXPRESS
+ *  OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ *  FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL
+ *  THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ *  LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+ *  FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
+ *  DEALINGS IN THE SOFTWARE.
+ *
+ *****************************************************************************/
+
+#ifndef TCLAP_IGNORE_REST_VISITOR_H
+#define TCLAP_IGNORE_REST_VISITOR_H
+
+#include <tclap/CmdLineInterface.h>
+#include <tclap/Visitor.h>
+
+namespace TCLAP {
+
+/**
+ * A Visitor that tells the CmdLine to begin ignoring arguments after
+ * this one is parsed.
+ */
+class IgnoreRestVisitor : public Visitor {
+public:
+    IgnoreRestVisitor(CmdLineInterface &cmdLine)
+        : Visitor(), cmdLine_(cmdLine) {}
+    void visit() { cmdLine_.beginIgnoring(); }
+
+private:
+    CmdLineInterface &cmdLine_;
+};
+}  // namespace TCLAP
+
+#endif  // TCLAP_IGNORE_REST_VISITOR_H

--- a/lib/tclap/MultiArg.h
+++ b/lib/tclap/MultiArg.h
@@ -1,0 +1,354 @@
+// -*- Mode: c++; c-basic-offset: 4; tab-width: 4; -*-
+
+/******************************************************************************
+ *
+ *  file:  MultiArg.h
+ *
+ *  Copyright (c) 2003, Michael E. Smoot .
+ *  Copyright (c) 2004, Michael E. Smoot, Daniel Aarno.
+ *  Copyright (c) 2017, Google LLC
+ *  All rights reserved.
+ *
+ *  See the file COPYING in the top directory of this distribution for
+ *  more information.
+ *
+ *  THE SOFTWARE IS PROVIDED _AS IS_, WITHOUT WARRANTY OF ANY KIND, EXPRESS
+ *  OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ *  FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL
+ *  THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ *  LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+ *  FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
+ *  DEALINGS IN THE SOFTWARE.
+ *
+ *****************************************************************************/
+
+#ifndef TCLAP_MULTI_ARG_H
+#define TCLAP_MULTI_ARG_H
+
+#include <tclap/Arg.h>
+#include <tclap/Constraint.h>
+
+#include <string>
+#include <vector>
+
+namespace TCLAP {
+/**
+ * An argument that allows multiple values of type T to be specified.  Very
+ * similar to a ValueArg, except a vector of values will be returned
+ * instead of just one.
+ */
+template <class T>
+class MultiArg : public Arg {
+public:
+    typedef std::vector<T> container_type;
+    typedef typename container_type::iterator iterator;
+    typedef typename container_type::const_iterator const_iterator;
+
+protected:
+    /**
+     * The list of values parsed from the CmdLine.
+     */
+    std::vector<T> _values;
+
+    /**
+     * The description of type T to be used in the usage.
+     */
+    std::string _typeDesc;
+
+    /**
+     * A list of constraint on this Arg.
+     */
+    Constraint<T> *_constraint;
+
+    /**
+     * Extracts the value from the string.
+     * Attempts to parse string as type T, if this fails an exception
+     * is thrown.
+     * \param val - The string to be read.
+     */
+    void _extractValue(const std::string &val);
+
+    /**
+     * Used by MultiArg to decide whether to keep parsing for this
+     * arg.
+     */
+    bool _allowMore;
+
+public:
+    /**
+     * Constructor.
+     * \param flag - The one character flag that identifies this
+     * argument on the command line.
+     * \param name - A one word name for the argument.  Can be
+     * used as a long flag on the command line.
+     * \param desc - A description of what the argument is for or
+     * does.
+     * \param req - Whether the argument is required on the command
+     * line.
+     * \param typeDesc - A short, human readable description of the
+     * type that this object expects.  This is used in the generation
+     * of the USAGE statement.  The goal is to be helpful to the end user
+     * of the program.
+     * \param v - An optional visitor.  You probably should not
+     * use this unless you have a very good reason.
+     */
+    MultiArg(const std::string &flag, const std::string &name,
+             const std::string &desc, bool req, const std::string &typeDesc,
+             Visitor *v = NULL);
+
+    /**
+     * Constructor.
+     * \param flag - The one character flag that identifies this
+     * argument on the command line.
+     * \param name - A one word name for the argument.  Can be
+     * used as a long flag on the command line.
+     * \param desc - A description of what the argument is for or
+     * does.
+     * \param req - Whether the argument is required on the command
+     * line.
+     * \param typeDesc - A short, human readable description of the
+     * type that this object expects.  This is used in the generation
+     * of the USAGE statement.  The goal is to be helpful to the end user
+     * of the program.
+     * \param parser - A CmdLine parser object to add this Arg to
+     * \param v - An optional visitor.  You probably should not
+     * use this unless you have a very good reason.
+     */
+    MultiArg(const std::string &flag, const std::string &name,
+             const std::string &desc, bool req, const std::string &typeDesc,
+             ArgContainer &parser, Visitor *v = NULL);
+
+    /**
+     * Constructor.
+     * \param flag - The one character flag that identifies this
+     * argument on the command line.
+     * \param name - A one word name for the argument.  Can be
+     * used as a long flag on the command line.
+     * \param desc - A description of what the argument is for or
+     * does.
+     * \param req - Whether the argument is required on the command
+     * line.
+     * \param constraint - A pointer to a Constraint object used
+     * to constrain this Arg.
+     * \param v - An optional visitor.  You probably should not
+     * use this unless you have a very good reason.
+     */
+    MultiArg(const std::string &flag, const std::string &name,
+             const std::string &desc, bool req, Constraint<T> *constraint,
+             Visitor *v = NULL);
+
+    /**
+     * Constructor.
+     * \param flag - The one character flag that identifies this
+     * argument on the command line.
+     * \param name - A one word name for the argument.  Can be
+     * used as a long flag on the command line.
+     * \param desc - A description of what the argument is for or
+     * does.
+     * \param req - Whether the argument is required on the command
+     * line.
+     * \param constraint - A pointer to a Constraint object used
+     * to constrain this Arg.
+     * \param parser - A CmdLine parser object to add this Arg to
+     * \param v - An optional visitor.  You probably should not
+     * use this unless you have a very good reason.
+     */
+    MultiArg(const std::string &flag, const std::string &name,
+             const std::string &desc, bool req, Constraint<T> *constraint,
+             ArgContainer &parser, Visitor *v = NULL);
+
+    /**
+     * Handles the processing of the argument.
+     * This re-implements the Arg version of this method to set the
+     * _value of the argument appropriately.  It knows the difference
+     * between labeled and unlabeled.
+     * \param i - Pointer the the current argument in the list.
+     * \param args - Mutable list of strings. Passed from main().
+     */
+    virtual bool processArg(int *i, std::vector<std::string> &args);
+
+    /**
+     * Returns a vector of type T containing the values parsed from
+     * the command line.
+     */
+    const std::vector<T> &getValue() const { return _values; }
+
+    /**
+     * Returns an iterator over the values parsed from the command
+     * line.
+     */
+    const_iterator begin() const { return _values.begin(); }
+
+    /**
+     * Returns the end of the values parsed from the command
+     * line.
+     */
+    const_iterator end() const { return _values.end(); }
+
+    /**
+     * Returns the a short id string.  Used in the usage.
+     * \param val - value to be used.
+     */
+    virtual std::string shortID(const std::string &val = "val") const;
+
+    /**
+     * Returns the a long id string.  Used in the usage.
+     * \param val - value to be used.
+     */
+    virtual std::string longID(const std::string &val = "val") const;
+
+    virtual bool allowMore();
+
+    virtual void reset();
+
+private:
+    /**
+     * Prevent accidental copying
+     */
+    MultiArg<T>(const MultiArg<T> &rhs);
+    MultiArg<T> &operator=(const MultiArg<T> &rhs);
+};
+
+template <class T>
+MultiArg<T>::MultiArg(const std::string &flag, const std::string &name,
+                      const std::string &desc, bool req,
+                      const std::string &typeDesc, Visitor *v)
+    : Arg(flag, name, desc, req, true, v),
+      _values(std::vector<T>()),
+      _typeDesc(typeDesc),
+      _constraint(NULL),
+      _allowMore(false) {
+    _acceptsMultipleValues = true;
+}
+
+template <class T>
+MultiArg<T>::MultiArg(const std::string &flag, const std::string &name,
+                      const std::string &desc, bool req,
+                      const std::string &typeDesc, ArgContainer &parser,
+                      Visitor *v)
+    : Arg(flag, name, desc, req, true, v),
+      _values(std::vector<T>()),
+      _typeDesc(typeDesc),
+      _constraint(NULL),
+      _allowMore(false) {
+    parser.add(this);
+    _acceptsMultipleValues = true;
+}
+
+/**
+ *
+ */
+template <class T>
+MultiArg<T>::MultiArg(const std::string &flag, const std::string &name,
+                      const std::string &desc, bool req,
+                      Constraint<T> *constraint, Visitor *v)
+    : Arg(flag, name, desc, req, true, v),
+      _values(std::vector<T>()),
+      _typeDesc(Constraint<T>::shortID(constraint)),
+      _constraint(constraint),
+      _allowMore(false) {
+    _acceptsMultipleValues = true;
+}
+
+template <class T>
+MultiArg<T>::MultiArg(const std::string &flag, const std::string &name,
+                      const std::string &desc, bool req,
+                      Constraint<T> *constraint, ArgContainer &parser,
+                      Visitor *v)
+    : Arg(flag, name, desc, req, true, v),
+      _values(std::vector<T>()),
+      _typeDesc(Constraint<T>::shortID(constraint)),
+      _constraint(constraint),
+      _allowMore(false) {
+    parser.add(this);
+    _acceptsMultipleValues = true;
+}
+
+template <class T>
+bool MultiArg<T>::processArg(int *i, std::vector<std::string> &args) {
+    if (_hasBlanks(args[*i])) return false;
+
+    std::string flag = args[*i];
+    std::string value = "";
+
+    trimFlag(flag, value);
+
+    if (argMatches(flag)) {
+        if (Arg::delimiter() != ' ' && value == "")
+            throw(ArgParseException(
+                "Couldn't find delimiter for this argument!", toString()));
+
+        // always take the first one, regardless of start string
+        if (value == "") {
+            (*i)++;
+            if (static_cast<unsigned int>(*i) < args.size())
+                _extractValue(args[*i]);
+            else
+                throw(ArgParseException("Missing a value for this argument!",
+                                        toString()));
+        } else {
+            _extractValue(value);
+        }
+
+        _alreadySet = true;
+        _setBy = flag;
+        _checkWithVisitor();
+
+        return true;
+    } else {
+        return false;
+    }
+}
+
+/**
+ *
+ */
+template <class T>
+std::string MultiArg<T>::shortID(const std::string &val) const {
+    static_cast<void>(val);  // Ignore input, don't warn
+    return Arg::shortID("<" + _typeDesc + ">") + " ...";
+}
+
+/**
+ *
+ */
+template <class T>
+std::string MultiArg<T>::longID(const std::string &val) const {
+    static_cast<void>(val);  // Ignore input, don't warn
+    return Arg::longID("<" + _typeDesc + ">") + "  (accepted multiple times)";
+}
+
+template <class T>
+void MultiArg<T>::_extractValue(const std::string &val) {
+    try {
+        T tmp;
+        ExtractValue(tmp, val, typename ArgTraits<T>::ValueCategory());
+        _values.push_back(tmp);
+    } catch (ArgParseException &e) {
+        throw ArgParseException(e.error(), toString());
+    }
+
+    if (_constraint != NULL)
+        if (!_constraint->check(_values.back()))
+            throw(CmdLineParseException(
+                "Value '" + val +
+                    "' does not meet constraint: " + _constraint->description(),
+                toString()));
+}
+
+template <class T>
+bool MultiArg<T>::allowMore() {
+    bool am = _allowMore;
+    _allowMore = true;
+    return am;
+}
+
+template <class T>
+void MultiArg<T>::reset() {
+    Arg::reset();
+    _values.clear();
+}
+
+}  // namespace TCLAP
+
+#endif  // TCLAP_MULTI_ARG_H

--- a/lib/tclap/MultiSwitchArg.h
+++ b/lib/tclap/MultiSwitchArg.h
@@ -1,0 +1,175 @@
+// -*- Mode: c++; c-basic-offset: 4; tab-width: 4; -*-
+
+/******************************************************************************
+ *
+ *  file:  MultiSwitchArg.h
+ *
+ *  Copyright (c) 2003, Michael E. Smoot .
+ *  Copyright (c) 2004, Michael E. Smoot, Daniel Aarno.
+ *  Copyright (c) 2005, Michael E. Smoot, Daniel Aarno, Erik Zeek.
+ *  Copyright (c) 2017, Google LLC
+ *  All rights reserved.
+ *
+ *  See the file COPYING in the top directory of this distribution for
+ *  more information.
+ *
+ *  THE SOFTWARE IS PROVIDED _AS IS_, WITHOUT WARRANTY OF ANY KIND, EXPRESS
+ *  OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ *  FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL
+ *  THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ *  LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+ *  FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
+ *  DEALINGS IN THE SOFTWARE.
+ *
+ *****************************************************************************/
+
+#ifndef TCLAP_MULTI_SWITCH_ARG_H
+#define TCLAP_MULTI_SWITCH_ARG_H
+
+#include <tclap/SwitchArg.h>
+
+#include <string>
+#include <vector>
+
+namespace TCLAP {
+
+/**
+ * A multiple switch argument.  If the switch is set on the command line, then
+ * the getValue method will return the number of times the switch appears.
+ */
+class MultiSwitchArg : public SwitchArg {
+protected:
+    /**
+     * The value of the switch.
+     */
+    int _value;
+
+    /**
+     * Used to support the reset() method so that ValueArg can be
+     * reset to their constructed value.
+     */
+    int _default;
+
+public:
+    /**
+     * MultiSwitchArg constructor.
+     * \param flag - The one character flag that identifies this
+     * argument on the command line.
+     * \param name - A one word name for the argument.  Can be
+     * used as a long flag on the command line.
+     * \param desc - A description of what the argument is for or
+     * does.
+     * \param init - Optional. The initial/default value of this Arg.
+     * Defaults to 0.
+     * \param v - An optional visitor.  You probably should not
+     * use this unless you have a very good reason.
+     */
+    MultiSwitchArg(const std::string &flag, const std::string &name,
+                   const std::string &desc, int init = 0, Visitor *v = NULL);
+
+    /**
+     * MultiSwitchArg constructor.
+     * \param flag - The one character flag that identifies this
+     * argument on the command line.
+     * \param name - A one word name for the argument.  Can be
+     * used as a long flag on the command line.
+     * \param desc - A description of what the argument is for or
+     * does.
+     * \param parser - A CmdLine parser object to add this Arg to
+     * \param init - Optional. The initial/default value of this Arg.
+     * Defaults to 0.
+     * \param v - An optional visitor.  You probably should not
+     * use this unless you have a very good reason.
+     */
+    MultiSwitchArg(const std::string &flag, const std::string &name,
+                   const std::string &desc, ArgContainer &parser, int init = 0,
+                   Visitor *v = NULL);
+
+    /**
+     * Handles the processing of the argument.
+     * This re-implements the SwitchArg version of this method to set the
+     * _value of the argument appropriately.
+     * \param i - Pointer the the current argument in the list.
+     * \param args - Mutable list of strings. Passed
+     * in from main().
+     */
+    virtual bool processArg(int *i, std::vector<std::string> &args);
+
+    /**
+     * Returns int, the number of times the switch has been set.
+     */
+    int getValue() const { return _value; }
+
+    /**
+     * Returns the shortID for this Arg.
+     */
+    std::string shortID(const std::string &val) const;
+
+    /**
+     * Returns the longID for this Arg.
+     */
+    std::string longID(const std::string &val) const;
+
+    void reset();
+};
+
+inline MultiSwitchArg::MultiSwitchArg(const std::string &flag,
+                                      const std::string &name,
+                                      const std::string &desc, int init,
+                                      Visitor *v)
+    : SwitchArg(flag, name, desc, false, v), _value(init), _default(init) {}
+
+inline MultiSwitchArg::MultiSwitchArg(const std::string &flag,
+                                      const std::string &name,
+                                      const std::string &desc,
+                                      ArgContainer &parser, int init,
+                                      Visitor *v)
+    : SwitchArg(flag, name, desc, false, v), _value(init), _default(init) {
+    parser.add(this);
+}
+
+inline bool MultiSwitchArg::processArg(int *i, std::vector<std::string> &args) {
+    if (argMatches(args[*i])) {
+        // so the isSet() method will work
+        _alreadySet = true;
+        _setBy = args[*i];
+
+        // Matched argument: increment value.
+        ++_value;
+
+        _checkWithVisitor();
+
+        return true;
+    } else if (combinedSwitchesMatch(args[*i])) {
+        // so the isSet() method will work
+        _alreadySet = true;
+
+        // Matched argument: increment value.
+        ++_value;
+
+        // Check for more in argument and increment value.
+        while (combinedSwitchesMatch(args[*i])) ++_value;
+
+        _checkWithVisitor();
+
+        return false;
+    } else {
+        return false;
+    }
+}
+
+inline std::string MultiSwitchArg::shortID(const std::string &val) const {
+    return Arg::shortID(val) + " ...";
+}
+
+inline std::string MultiSwitchArg::longID(const std::string &val) const {
+    return Arg::longID(val) + "  (accepted multiple times)";
+}
+
+inline void MultiSwitchArg::reset() {
+    MultiSwitchArg::_value = MultiSwitchArg::_default;
+}
+
+}  // namespace TCLAP
+
+#endif  // TCLAP_MULTI_SWITCH_ARG_H

--- a/lib/tclap/OptionalUnlabeledTracker.h
+++ b/lib/tclap/OptionalUnlabeledTracker.h
@@ -1,0 +1,58 @@
+// -*- Mode: c++; c-basic-offset: 4; tab-width: 4; -*-
+
+/******************************************************************************
+ *
+ *  file:  OptionalUnlabeledTracker.h
+ *
+ *  Copyright (c) 2005, Michael E. Smoot .
+ *  All rights reserved.
+ *
+ *  See the file COPYING in the top directory of this distribution for
+ *  more information.
+ *
+ *  THE SOFTWARE IS PROVIDED _AS IS_, WITHOUT WARRANTY OF ANY KIND, EXPRESS
+ *  OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ *  FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL
+ *  THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ *  LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+ *  FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
+ *  DEALINGS IN THE SOFTWARE.
+ *
+ *****************************************************************************/
+
+#ifndef TCLAP_OPTIONAL_UNLABELED_TRACKER_H
+#define TCLAP_OPTIONAL_UNLABELED_TRACKER_H
+
+#include <string>
+
+namespace TCLAP {
+
+class OptionalUnlabeledTracker {
+public:
+    static void check(bool req, const std::string &argName);
+
+    static void gotOptional() { alreadyOptionalRef() = true; }
+
+    static bool &alreadyOptional() { return alreadyOptionalRef(); }
+
+private:
+    static bool &alreadyOptionalRef() {
+        static bool ct = false;
+        return ct;
+    }
+};
+
+inline void OptionalUnlabeledTracker::check(bool req,
+                                            const std::string &argName) {
+    if (OptionalUnlabeledTracker::alreadyOptional())
+        throw(SpecificationException(
+            "You can't specify ANY Unlabeled Arg following an optional "
+            "Unlabeled Arg",
+            argName));
+
+    if (!req) OptionalUnlabeledTracker::gotOptional();
+}
+
+}  // namespace TCLAP
+
+#endif  // TCLAP_OPTIONAL_UNLABELED_TRACKER_H

--- a/lib/tclap/StandardTraits.h
+++ b/lib/tclap/StandardTraits.h
@@ -1,0 +1,59 @@
+// -*- Mode: c++; c-basic-offset: 4; tab-width: 4; -*-
+
+/******************************************************************************
+ *
+ *  file:  StandardTraits.h
+ *
+ *  Copyright (c) 2007, Daniel Aarno, Michael E. Smoot .
+ *  Copyright (c) 2017, Google LLC
+ *  All rights reserved.
+ *
+ *  See the file COPYING in the top directory of this distribution for
+ *  more information.
+ *
+ *  THE SOFTWARE IS PROVIDED _AS IS_, WITHOUT WARRANTY OF ANY KIND, EXPRESS
+ *  OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ *  FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL
+ *  THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ *  LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+ *  FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
+ *  DEALINGS IN THE SOFTWARE.
+ *
+ *****************************************************************************/
+
+// This is an internal tclap file, you should probably not have to
+// include this directly
+
+#ifndef TCLAP_STANDARD_TRAITS_H
+#define TCLAP_STANDARD_TRAITS_H
+
+#include <string>
+
+// If Microsoft has already typedef'd wchar_t as an unsigned
+// short, then compiles will break because it's as if we're
+// creating ArgTraits twice for unsigned short. Thus...
+#ifdef _MSC_VER
+#ifndef _NATIVE_WCHAR_T_DEFINED
+#define TCLAP_DONT_DECLARE_WCHAR_T_ARGTRAITS
+#endif
+#endif
+
+namespace TCLAP {
+
+// Integer types (signed, unsigned and bool) and floating point types all
+// have value-like semantics.
+
+// Strings have string like argument traits.
+template <>
+struct ArgTraits<std::string> {
+    typedef StringLike ValueCategory;
+};
+
+template <typename T>
+void SetString(T &dst, const std::string &src) {
+    dst = src;
+}
+
+}  // namespace TCLAP
+
+#endif  // TCLAP_STANDARD_TRAITS_H

--- a/lib/tclap/StdOutput.h
+++ b/lib/tclap/StdOutput.h
@@ -1,0 +1,505 @@
+// -*- Mode: c++; c-basic-offset: 4; tab-width: 4; -*-
+
+/******************************************************************************
+ *
+ *  file:  StdOutput.h
+ *
+ *  Copyright (c) 2004, Michael E. Smoot
+ *  Copyright (c) 2017, Google LLC
+ *  All rights reserved.
+ *
+ *  See the file COPYING in the top directory of this distribution for
+ *  more information.
+ *
+ *  THE SOFTWARE IS PROVIDED _AS IS_, WITHOUT WARRANTY OF ANY KIND, EXPRESS
+ *  OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ *  FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL
+ *  THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ *  LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+ *  FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
+ *  DEALINGS IN THE SOFTWARE.
+ *
+ *****************************************************************************/
+
+#ifndef TCLAP_STD_OUTPUT_H
+#define TCLAP_STD_OUTPUT_H
+
+#include <tclap/Arg.h>
+#include <tclap/ArgGroup.h>
+#include <tclap/CmdLineInterface.h>
+#include <tclap/CmdLineOutput.h>
+
+#include <algorithm>
+#include <cctype>
+#include <iostream>
+#include <list>
+#include <string>
+#include <utility>
+#include <vector>
+
+namespace TCLAP {
+
+/**
+ * A class that isolates any output from the CmdLine object so that it
+ * may be easily modified.
+ */
+class StdOutput : public CmdLineOutput {
+public:
+    /**
+     * Prints the usage to stdout.  Can be overridden to
+     * produce alternative behavior.
+     * \param c - The CmdLine object the output is generated for.
+     */
+    virtual void usage(CmdLineInterface &c);
+
+    /**
+     * Prints the version to stdout. Can be overridden
+     * to produce alternative behavior.
+     * \param c - The CmdLine object the output is generated for.
+     */
+    virtual void version(CmdLineInterface &c);
+
+    /**
+     * Prints (to stderr) an error message, short usage
+     * Can be overridden to produce alternative behavior.
+     * \param c - The CmdLine object the output is generated for.
+     * \param e - The ArgException that caused the failure.
+     */
+    virtual void failure(CmdLineInterface &c, ArgException &e);
+
+protected:
+    /**
+     * Writes a brief usage message with short args.
+     * \param c - The CmdLine object the output is generated for.
+     * \param os - The stream to write the message to.
+     */
+    void _shortUsage(CmdLineInterface &c, std::ostream &os) const;
+
+    /**
+     * Writes a longer usage message with long and short args,
+     * provides descriptions and prints message.
+     * \param c - The CmdLine object the output is generated for.
+     * \param os - The stream to write the message to.
+     */
+    void _longUsage(CmdLineInterface &c, std::ostream &os) const;
+
+    /**
+     * This function inserts line breaks and indents long strings
+     * according the  params input. It will only break lines at spaces,
+     * commas and pipes.
+     * \param os - The stream to be printed to.
+     * \param s - The string to be printed.
+     * \param maxWidth - The maxWidth allowed for the output line.
+     * \param indentSpaces - The number of spaces to indent the first line.
+     * \param secondLineOffset - The number of spaces to indent the second
+     * and all subsequent lines in addition to indentSpaces.
+     */
+    void spacePrint(std::ostream &os, const std::string &s, int maxWidth,
+                    int indentSpaces, int secondLineOffset) const;
+};
+
+inline void StdOutput::version(CmdLineInterface &_cmd) {
+    std::string progName = _cmd.getProgramName();
+    std::string xversion = _cmd.getVersion();
+
+    std::cout << std::endl
+              << progName << "  version: " << xversion << std::endl
+              << std::endl;
+}
+
+inline void StdOutput::usage(CmdLineInterface &_cmd) {
+    std::cout << std::endl << "USAGE: " << std::endl << std::endl;
+
+    _shortUsage(_cmd, std::cout);
+
+    std::cout << std::endl << std::endl << "Where: " << std::endl << std::endl;
+
+    _longUsage(_cmd, std::cout);
+
+    std::cout << std::endl;
+}
+
+inline void StdOutput::failure(CmdLineInterface &_cmd, ArgException &e) {
+    std::string progName = _cmd.getProgramName();
+
+    std::cerr << "PARSE ERROR: " << e.argId() << std::endl
+              << "             " << e.error() << std::endl
+              << std::endl;
+
+    if (_cmd.hasHelpAndVersion()) {
+        std::cerr << "Brief USAGE: " << std::endl;
+
+        _shortUsage(_cmd, std::cerr);
+
+        std::cerr << std::endl
+                  << "For complete USAGE and HELP type: " << std::endl
+                  << "   " << progName << " " << Arg::nameStartString()
+                  << "help" << std::endl
+                  << std::endl;
+    } else {
+        usage(_cmd);
+    }
+
+    throw ExitException(1);
+}
+
+// TODO: Remove this
+inline void removeChar(std::string &s, char r) {
+    size_t p;
+    while ((p = s.find_first_of(r)) != std::string::npos) {
+        s.erase(p, 1);
+    }
+}
+
+inline bool cmpSwitch(const char &a, const char &b) {
+    int lowa = std::tolower(a);
+    int lowb = std::tolower(b);
+
+    if (lowa == lowb) {
+        return a < b;
+    }
+
+    return lowa < lowb;
+}
+
+namespace internal {
+inline bool IsVisibleShortSwitch(const Arg &arg) {
+    return !(arg.getName() == Arg::ignoreNameString() ||
+             arg.isValueRequired() || arg.getFlag() == "") &&
+           arg.visibleInHelp();
+}
+
+inline bool IsVisibleLongSwitch(const Arg &arg) {
+    return (arg.getName() != Arg::ignoreNameString() &&
+            !arg.isValueRequired() && arg.getFlag() == "" &&
+            arg.visibleInHelp());
+}
+
+inline bool IsVisibleOption(const Arg &arg) {
+    return (arg.getName() != Arg::ignoreNameString() && arg.isValueRequired() &&
+            arg.hasLabel() && arg.visibleInHelp());
+}
+
+inline bool CompareShortID(const Arg *a, const Arg *b) {
+    if (a->getFlag() == "" && b->getFlag() != "") {
+        return false;
+    }
+    if (b->getFlag() == "" && a->getFlag() != "") {
+        return true;
+    }
+
+    return a->shortID() < b->shortID();
+}
+
+// TODO: Fix me not to put --gopt before -f
+inline bool CompareOptions(std::pair<const Arg *, bool> a,
+                           std::pair<const Arg *, bool> b) {
+    // First optional, then required
+    if (!a.second && b.second) {
+        return true;
+    }
+    if (a.second && !b.second) {
+        return false;
+    }
+
+    return CompareShortID(a.first, b.first);
+}
+}  // namespace internal
+
+/**
+ * Usage statements should look like the manual pages.  Options w/o
+ * operands come first, in alphabetical order inside a single set of
+ * braces, upper case before lower case (AaBbCc...).  Next are options
+ * with operands, in the same order, each in braces.  Then required
+ * arguments in the order they are specified, followed by optional
+ * arguments in the order they are specified.  A bar (`|') separates
+ * either/or options/arguments, and multiple options/arguments which
+ * are specified together are placed in a single set of braces.
+ *
+ * Use getprogname() instead of hardcoding the program name.
+ *
+ * "usage: f [-aDde] [-b b_arg] [-m m_arg] req1 req2 [opt1 [opt2]]\n"
+ * "usage: f [-a | -b] [-c [-de] [-n number]]\n"
+ */
+inline void StdOutput::_shortUsage(CmdLineInterface &_cmd,
+                                   std::ostream &os) const {
+    std::list<ArgGroup *> argSets = _cmd.getArgGroups();
+
+    std::ostringstream outp;
+    outp << _cmd.getProgramName() + " ";
+
+    std::string switches = Arg::flagStartString();
+
+    std::list<ArgGroup *> exclusiveGroups;
+    std::list<ArgGroup *> nonExclusiveGroups;
+    for (std::list<ArgGroup *>::iterator sit = argSets.begin();
+         sit != argSets.end(); ++sit) {
+        if (CountVisibleArgs(**sit) <= 0) {
+            continue;
+        }
+
+        if ((*sit)->isExclusive()) {
+            exclusiveGroups.push_back(*sit);
+        } else {
+            nonExclusiveGroups.push_back(*sit);
+        }
+    }
+
+    // Move "exclusive groups" that have at most a single item to
+    // non-exclusive groups as exclusivit doesn't make sense with a
+    // single option. This can happen if args are hidden in help for
+    // example.
+    for (std::list<ArgGroup *>::iterator it = exclusiveGroups.begin();
+         it != exclusiveGroups.end();) {
+        if (CountVisibleArgs(**it) < 2) {
+            nonExclusiveGroups.push_back(*it);
+            it = exclusiveGroups.erase(it);
+        } else {
+            ++it;
+        }
+    }
+
+    // First short switches (needs to be special because they are all
+    // stuck together).
+    for (std::list<ArgGroup *>::iterator sit = nonExclusiveGroups.begin();
+         sit != nonExclusiveGroups.end(); ++sit) {
+        for (ArgGroup::iterator it = (*sit)->begin(); it != (*sit)->end();
+             ++it) {
+            if (internal::IsVisibleShortSwitch(**it)) {
+                switches += (*it)->getFlag();
+            }
+        }
+
+        std::sort(switches.begin(), switches.end(), cmpSwitch);
+    }
+
+    outp << " [" << switches << ']';
+
+    // Now do long switches (e.g., --version, but no -v)
+    std::vector<Arg *> longSwitches;
+    for (std::list<ArgGroup *>::iterator sit = nonExclusiveGroups.begin();
+         sit != nonExclusiveGroups.end(); ++sit) {
+        for (ArgGroup::iterator it = (*sit)->begin(); it != (*sit)->end();
+             ++it) {
+            Arg &arg = **it;
+            if (internal::IsVisibleLongSwitch(arg)) {
+                longSwitches.push_back(&arg);
+            }
+        }
+    }
+
+    std::sort(longSwitches.begin(), longSwitches.end(),
+              internal::CompareShortID);
+    for (std::vector<Arg *>::const_iterator it = longSwitches.begin();
+         it != longSwitches.end(); ++it) {
+        outp << " [" << (**it).shortID() << ']';
+    }
+
+    // Now do all exclusive groups
+    for (std::list<ArgGroup *>::iterator sit = exclusiveGroups.begin();
+         sit != exclusiveGroups.end(); ++sit) {
+        ArgGroup &argGroup = **sit;
+        outp << (argGroup.isRequired() ? " {" : " [");
+
+        std::vector<Arg *> args;
+        for (ArgGroup::iterator it = argGroup.begin(); it != argGroup.end();
+             ++it) {
+            if ((**it).visibleInHelp()) {
+                args.push_back(*it);
+            }
+        }
+
+        std::sort(args.begin(), args.end(), internal::CompareShortID);
+        std::string sep = "";
+        for (std::vector<Arg *>::const_iterator it = args.begin();
+             it != args.end(); ++it) {
+            outp << sep << (**it).shortID();
+            sep = "|";
+        }
+
+        outp << (argGroup.isRequired() ? '}' : ']');
+    }
+
+    // Next do options, we sort them later by optional first.
+    std::vector<std::pair<const Arg *, bool> > options;
+    for (std::list<ArgGroup *>::iterator sit = nonExclusiveGroups.begin();
+         sit != nonExclusiveGroups.end(); ++sit) {
+        for (ArgGroup::iterator it = (*sit)->begin(); it != (*sit)->end();
+             ++it) {
+            Arg &arg = **it;
+            int visible = CountVisibleArgs(**sit);
+            bool required = arg.isRequired();
+            if (internal::IsVisibleOption(arg)) {
+                if (visible == 1 && (**sit).isRequired()) {
+                    required = true;
+                }
+
+                options.push_back(std::make_pair(&arg, required));
+            }
+        }
+    }
+
+    std::sort(options.begin(), options.end(), internal::CompareOptions);
+    for (std::vector<std::pair<const Arg *, bool> >::const_iterator it =
+             options.begin();
+         it != options.end(); ++it) {
+        const Arg &arg = *it->first;
+        bool required = it->second;
+        outp << (required ? " " : " [");
+        outp << arg.shortID();
+        outp << (required ? "" : "]");
+    }
+
+    // Next do argsuments ("unlabled") in order of definition
+    for (std::list<ArgGroup *>::iterator sit = nonExclusiveGroups.begin();
+         sit != nonExclusiveGroups.end(); ++sit) {
+        for (ArgGroup::iterator it = (*sit)->begin(); it != (*sit)->end();
+             ++it) {
+            Arg &arg = **it;
+            if (arg.getName() == Arg::ignoreNameString()) {
+                continue;
+            }
+
+            if (arg.isValueRequired() && !arg.hasLabel() &&
+                arg.visibleInHelp()) {
+                outp << (arg.isRequired() ? " " : " [");
+                outp << arg.shortID();
+                outp << (arg.isRequired() ? "" : "]");
+            }
+        }
+    }
+
+    // if the program name is too long, then adjust the second line offset
+    int secondLineOffset = static_cast<int>(_cmd.getProgramName().length()) + 2;
+    if (secondLineOffset > 75 / 2) secondLineOffset = static_cast<int>(75 / 2);
+
+    spacePrint(os, outp.str(), 75, 3, secondLineOffset);
+}
+
+inline void StdOutput::_longUsage(CmdLineInterface &_cmd,
+                                  std::ostream &os) const {
+    std::string message = _cmd.getMessage();
+    std::list<ArgGroup *> argSets = _cmd.getArgGroups();
+
+    std::list<Arg *> unlabled;
+    for (std::list<ArgGroup *>::iterator sit = argSets.begin();
+         sit != argSets.end(); ++sit) {
+        ArgGroup &argGroup = **sit;
+
+        int visible = CountVisibleArgs(argGroup);
+        bool exclusive = visible > 1 && argGroup.isExclusive();
+        bool forceRequired = visible == 1 && argGroup.isRequired();
+        if (exclusive) {
+            spacePrint(os, argGroup.isRequired() ? "One of:" : "Either of:", 75,
+                       3, 0);
+        }
+
+        for (ArgGroup::iterator it = argGroup.begin(); it != argGroup.end();
+             ++it) {
+            Arg &arg = **it;
+            if (!arg.visibleInHelp()) {
+                continue;
+            }
+
+            if (!arg.hasLabel()) {
+                unlabled.push_back(&arg);
+                continue;
+            }
+
+            bool required = arg.isRequired() || forceRequired;
+            if (exclusive) {
+                spacePrint(os, arg.longID(), 75, 6, 3);
+                spacePrint(os, arg.getDescription(required), 75, 8, 0);
+            } else {
+                spacePrint(os, arg.longID(), 75, 3, 3);
+                spacePrint(os, arg.getDescription(required), 75, 5, 0);
+            }
+            os << '\n';
+        }
+    }
+
+    for (ArgListIterator it = unlabled.begin(); it != unlabled.end(); ++it) {
+        const Arg &arg = **it;
+        spacePrint(os, arg.longID(), 75, 3, 3);
+        spacePrint(os, arg.getDescription(), 75, 5, 0);
+        os << '\n';
+    }
+
+    if (!message.empty()) {
+        spacePrint(os, message, 75, 3, 0);
+    }
+
+    os.flush();
+}
+
+namespace {
+inline void fmtPrintLine(std::ostream &os, const std::string &s, int maxWidth,
+                         int indentSpaces, int secondLineOffset) {
+    const std::string splitChars(" ,|");
+    int maxChars = maxWidth - indentSpaces;
+    std::string indentString(indentSpaces, ' ');
+    int from = 0;
+    int to = 0;
+    int end = s.length();
+    for (;;) {
+        if (end - from <= maxChars) {
+            // Rest of string fits on line, just print the remainder
+            os << indentString << s.substr(from) << std::endl;
+            return;
+        }
+
+        // Find the next place where it is good to break the string
+        // (to) by finding the place where it is too late (tooFar) and
+        // taking the previous one.
+        int tooFar = to;
+        while (tooFar - from <= maxChars &&
+               static_cast<std::size_t>(tooFar) != std::string::npos) {
+            to = tooFar;
+            tooFar = s.find_first_of(splitChars, to + 1);
+        }
+
+        if (to == from) {
+            // In case there was no good place to break the string,
+            // just break it in the middle of a word at line length.
+            to = from + maxChars - 1;
+        }
+
+        if (s[to] != ' ') {
+            // Include delimiter before line break, unless it's a space
+            to++;
+        }
+
+        os << indentString << s.substr(from, to - from) << '\n';
+
+        // Avoid printing extra white space at start of a line
+        for (; s[to] == ' '; to++) {
+        }
+        from = to;
+
+        if (secondLineOffset != 0) {
+            // Adjust offset for following lines
+            indentString.insert(indentString.end(), secondLineOffset, ' ');
+            maxChars -= secondLineOffset;
+            secondLineOffset = 0;
+        }
+    }
+}
+}  // namespace
+
+inline void StdOutput::spacePrint(std::ostream &os, const std::string &s,
+                                  int maxWidth, int indentSpaces,
+                                  int secondLineOffset) const {
+    std::stringstream ss(s);
+    std::string line;
+    std::getline(ss, line);
+    fmtPrintLine(os, line, maxWidth, indentSpaces, secondLineOffset);
+    indentSpaces += secondLineOffset;
+
+    while (std::getline(ss, line)) {
+        fmtPrintLine(os, line, maxWidth, indentSpaces, 0);
+    }
+}
+
+}  // namespace TCLAP
+
+#endif  // TCLAP_STD_OUTPUT_H

--- a/lib/tclap/SwitchArg.h
+++ b/lib/tclap/SwitchArg.h
@@ -1,0 +1,235 @@
+// -*- Mode: c++; c-basic-offset: 4; tab-width: 4; -*-
+
+/******************************************************************************
+ *
+ *  file:  SwitchArg.h
+ *
+ *  Copyright (c) 2003, Michael E. Smoot .
+ *  Copyright (c) 2004, Michael E. Smoot, Daniel Aarno.
+ *  Copyright (c) 2017, Google LLC
+ *  All rights reserved.
+ *
+ *  See the file COPYING in the top directory of this distribution for
+ *  more information.
+ *
+ *  THE SOFTWARE IS PROVIDED _AS IS_, WITHOUT WARRANTY OF ANY KIND, EXPRESS
+ *  OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ *  FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL
+ *  THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ *  LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+ *  FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
+ *  DEALINGS IN THE SOFTWARE.
+ *
+ *****************************************************************************/
+
+#ifndef TCLAP_SWITCH_ARG_H
+#define TCLAP_SWITCH_ARG_H
+
+#include <tclap/Arg.h>
+
+#include <string>
+#include <vector>
+
+namespace TCLAP {
+
+/**
+ * A simple switch argument.  If the switch is set on the command line, then
+ * the getValue method will return the opposite of the default value for the
+ * switch.
+ */
+class SwitchArg : public Arg {
+protected:
+    /**
+     * The value of the switch.
+     */
+    bool _value;
+
+    /**
+     * Used to support the reset() method so that ValueArg can be
+     * reset to their constructed value.
+     */
+    bool _default;
+
+public:
+    /**
+     * SwitchArg constructor.
+     * \param flag - The one character flag that identifies this
+     * argument on the command line.
+     * \param name - A one word name for the argument.  Can be
+     * used as a long flag on the command line.
+     * \param desc - A description of what the argument is for or
+     * does.
+     * \param def - The default value for this Switch.
+     * \param v - An optional visitor.  You probably should not
+     * use this unless you have a very good reason.
+     */
+    SwitchArg(const std::string &flag, const std::string &name,
+              const std::string &desc, bool def = false, Visitor *v = NULL);
+
+    /**
+     * SwitchArg constructor.
+     * \param flag - The one character flag that identifies this
+     * argument on the command line.
+     * \param name - A one word name for the argument.  Can be
+     * used as a long flag on the command line.
+     * \param desc - A description of what the argument is for or
+     * does.
+     * \param parser - A CmdLine parser object to add this Arg to
+     * \param def - The default value for this Switch.
+     * \param v - An optional visitor.  You probably should not
+     * use this unless you have a very good reason.
+     */
+    SwitchArg(const std::string &flag, const std::string &name,
+              const std::string &desc, ArgContainer &parser, bool def = false,
+              Visitor *v = NULL);
+
+    /**
+     * Handles the processing of the argument.
+     * This re-implements the Arg version of this method to set the
+     * _value of the argument appropriately.
+     * \param i - Pointer the the current argument in the list.
+     * \param args - Mutable list of strings. Passed
+     * in from main().
+     */
+    virtual bool processArg(int *i, std::vector<std::string> &args);
+
+    /**
+     * Checks a string to see if any of the chars in the string
+     * match the flag for this Switch.
+     */
+    bool combinedSwitchesMatch(std::string &combined);
+
+    /**
+     * Returns bool, whether or not the switch has been set.
+     */
+    bool getValue() const { return _value; }
+
+    /**
+     * A SwitchArg can be used as a boolean, indicating
+     * whether or not the switch has been set. This is the
+     * same as calling getValue()
+     */
+    operator bool() const { return _value; }
+
+    virtual void reset();
+
+private:
+    /**
+     * Checks to see if we've found the last match in
+     * a combined string.
+     */
+    bool lastCombined(std::string &combined);
+
+    /**
+     * Does the common processing of processArg.
+     */
+    void commonProcessing();
+};
+
+//////////////////////////////////////////////////////////////////////
+// BEGIN SwitchArg.cpp
+//////////////////////////////////////////////////////////////////////
+inline SwitchArg::SwitchArg(const std::string &flag, const std::string &name,
+                            const std::string &desc, bool default_val,
+                            Visitor *v)
+    : Arg(flag, name, desc, false, false, v),
+      _value(default_val),
+      _default(default_val) {}
+
+inline SwitchArg::SwitchArg(const std::string &flag, const std::string &name,
+                            const std::string &desc, ArgContainer &parser,
+                            bool default_val, Visitor *v)
+    : Arg(flag, name, desc, false, false, v),
+      _value(default_val),
+      _default(default_val) {
+    parser.add(this);
+}
+
+inline bool SwitchArg::lastCombined(std::string &combinedSwitches) {
+    for (unsigned int i = 1; i < combinedSwitches.length(); i++)
+        if (combinedSwitches[i] != Arg::blankChar()) return false;
+
+    return true;
+}
+
+inline bool SwitchArg::combinedSwitchesMatch(std::string &combinedSwitches) {
+    // make sure this is actually a combined switch
+    if (combinedSwitches.length() > 0 &&
+        combinedSwitches[0] != Arg::flagStartString()[0])
+        return false;
+
+    // make sure it isn't a long name
+    if (combinedSwitches.substr(0, Arg::nameStartString().length()) ==
+        Arg::nameStartString())
+        return false;
+
+    // make sure the delimiter isn't in the string
+    if (combinedSwitches.find_first_of(Arg::delimiter()) != std::string::npos)
+        return false;
+
+    // ok, we're not specifying a ValueArg, so we know that we have
+    // a combined switch list.
+    for (unsigned int i = 1; i < combinedSwitches.length(); i++) {
+        if (_flag.length() > 0 && combinedSwitches[i] == _flag[0] &&
+            _flag[0] != Arg::flagStartString()[0]) {
+            // update the combined switches so this one is no longer
+            // present this is necessary so that no unlabeled args are
+            // matched later in the processing.
+            // combinedSwitches.erase(i,1);
+            _setBy = Arg::flagStartString() + combinedSwitches[i];
+            combinedSwitches[i] = Arg::blankChar();
+            return true;
+        }
+    }
+
+    // none of the switches passed in the list match.
+    return false;
+}
+
+inline void SwitchArg::commonProcessing() {
+    if (_alreadySet)
+        throw(CmdLineParseException("Argument already set!", toString()));
+
+    _alreadySet = true;
+
+    if (_value == true)
+        _value = false;
+    else
+        _value = true;
+
+    _checkWithVisitor();
+}
+
+inline bool SwitchArg::processArg(int *i, std::vector<std::string> &args) {
+    if (argMatches(args[*i])) {
+        // The whole string matches the flag or name string
+        _setBy = args[*i];
+        commonProcessing();
+
+        return true;
+    } else if (combinedSwitchesMatch(args[*i])) {
+        // A substring matches the flag as part of a combination
+        // check again to ensure we don't misinterpret
+        // this as a MultiSwitchArg
+        if (combinedSwitchesMatch(args[*i]))
+            throw(CmdLineParseException("Argument already set!", toString()));
+
+        commonProcessing();
+
+        // We only want to return true if we've found the last combined
+        // match in the string, otherwise we return true so that other
+        // switches in the combination will have a chance to match.
+        return lastCombined(args[*i]);
+    }
+
+    return false;
+}
+
+inline void SwitchArg::reset() {
+    Arg::reset();
+    _value = _default;
+}
+
+}  // namespace TCLAP
+
+#endif  // TCLAP_SWITCH_ARG_H

--- a/lib/tclap/UnlabeledMultiArg.h
+++ b/lib/tclap/UnlabeledMultiArg.h
@@ -1,0 +1,260 @@
+// -*- Mode: c++; c-basic-offset: 4; tab-width: 4; -*-
+
+/******************************************************************************
+ *
+ *  file:  UnlabeledMultiArg.h
+ *
+ *  Copyright (c) 2003, Michael E. Smoot.
+ *  Copyright (c) 2017, Google LLC
+ *  All rights reserved.
+ *
+ *  See the file COPYING in the top directory of this distribution for
+ *  more information.
+ *
+ *  THE SOFTWARE IS PROVIDED _AS IS_, WITHOUT WARRANTY OF ANY KIND, EXPRESS
+ *  OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ *  FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL
+ *  THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ *  LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+ *  FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
+ *  DEALINGS IN THE SOFTWARE.
+ *
+ *****************************************************************************/
+
+#ifndef TCLAP_UNLABELED_MULTI_ARG_H
+#define TCLAP_UNLABELED_MULTI_ARG_H
+
+#include <tclap/MultiArg.h>
+#include <tclap/OptionalUnlabeledTracker.h>
+
+#include <list>
+#include <string>
+#include <vector>
+
+namespace TCLAP {
+
+/**
+ * Just like a MultiArg, except that the arguments are unlabeled.  Basically,
+ * this Arg will slurp up everything that hasn't been matched to another
+ * Arg.
+ */
+template <class T>
+class UnlabeledMultiArg : public MultiArg<T> {
+    // If compiler has two stage name lookup (as gcc >= 3.4 does)
+    // this is required to prevent undef. symbols
+    using MultiArg<T>::_ignoreable;
+    using MultiArg<T>::_hasBlanks;
+    using MultiArg<T>::_extractValue;
+    using MultiArg<T>::_typeDesc;
+    using MultiArg<T>::_name;
+    using MultiArg<T>::_description;
+    using MultiArg<T>::_alreadySet;
+    using MultiArg<T>::_setBy;
+    using MultiArg<T>::toString;
+
+public:
+    /**
+     * Constructor.
+     * \param name - The name of the Arg. Note that this is used for
+     * identification, not as a long flag.
+     * \param desc - A description of what the argument is for or
+     * does.
+     * \param req - Whether the argument is required on the command
+     *  line.
+     * \param typeDesc - A short, human readable description of the
+     * type that this object expects.  This is used in the generation
+     * of the USAGE statement.  The goal is to be helpful to the end user
+     * of the program.
+     * \param ignoreable - Whether or not this argument can be ignored
+     * using the "--" flag.
+     * \param v - An optional visitor.  You probably should not
+     * use this unless you have a very good reason.
+     */
+    UnlabeledMultiArg(const std::string &name, const std::string &desc,
+                      bool req, const std::string &typeDesc,
+                      bool ignoreable = false, Visitor *v = NULL);
+    /**
+     * Constructor.
+     * \param name - The name of the Arg. Note that this is used for
+     * identification, not as a long flag.
+     * \param desc - A description of what the argument is for or
+     * does.
+     * \param req - Whether the argument is required on the command
+     *  line.
+     * \param typeDesc - A short, human readable description of the
+     * type that this object expects.  This is used in the generation
+     * of the USAGE statement.  The goal is to be helpful to the end user
+     * of the program.
+     * \param parser - A CmdLine parser object to add this Arg to
+     * \param ignoreable - Whether or not this argument can be ignored
+     * using the "--" flag.
+     * \param v - An optional visitor.  You probably should not
+     * use this unless you have a very good reason.
+     */
+    UnlabeledMultiArg(const std::string &name, const std::string &desc,
+                      bool req, const std::string &typeDesc,
+                      ArgContainer &parser, bool ignoreable = false,
+                      Visitor *v = NULL);
+
+    /**
+     * Constructor.
+     * \param name - The name of the Arg. Note that this is used for
+     * identification, not as a long flag.
+     * \param desc - A description of what the argument is for or
+     * does.
+     * \param req - Whether the argument is required on the command
+     *  line.
+     * \param constraint - A pointer to a Constraint object used
+     * to constrain this Arg.
+     * \param ignoreable - Whether or not this argument can be ignored
+     * using the "--" flag.
+     * \param v - An optional visitor.  You probably should not
+     * use this unless you have a very good reason.
+     */
+    UnlabeledMultiArg(const std::string &name, const std::string &desc,
+                      bool req, Constraint<T> *constraint,
+                      bool ignoreable = false, Visitor *v = NULL);
+
+    /**
+     * Constructor.
+     * \param name - The name of the Arg. Note that this is used for
+     * identification, not as a long flag.
+     * \param desc - A description of what the argument is for or
+     * does.
+     * \param req - Whether the argument is required on the command
+     *  line.
+     * \param constraint - A pointer to a Constraint object used
+     * to constrain this Arg.
+     * \param parser - A CmdLine parser object to add this Arg to
+     * \param ignoreable - Whether or not this argument can be ignored
+     * using the "--" flag.
+     * \param v - An optional visitor.  You probably should not
+     * use this unless you have a very good reason.
+     */
+    UnlabeledMultiArg(const std::string &name, const std::string &desc,
+                      bool req, Constraint<T> *constraint, ArgContainer &parser,
+                      bool ignoreable = false, Visitor *v = NULL);
+
+    /**
+     * Handles the processing of the argument.
+     * This re-implements the Arg version of this method to set the
+     * _value of the argument appropriately.  It knows the difference
+     * between labeled and unlabeled.
+     * \param i - Pointer the the current argument in the list.
+     * \param args - Mutable list of strings. Passed from main().
+     */
+    virtual bool processArg(int *i, std::vector<std::string> &args);
+
+    /**
+     * Returns the a short id string.  Used in the usage.
+     */
+    virtual std::string shortID(const std::string &) const {
+        return Arg::getName() + " ...";
+    }
+
+    /**
+     * Returns the a long id string.  Used in the usage.
+     * \param val - value to be used.
+     */
+    virtual std::string longID(const std::string &) const {
+        return Arg::getName() + " (accepted multiple times) <" + _typeDesc +
+               ">";
+    }
+
+    /**
+     * Operator ==.
+     * \param a - The Arg to be compared to this.
+     */
+    virtual bool operator==(const Arg &a) const;
+
+    /**
+     * Pushes this to back of list rather than front.
+     * \param argList - The list this should be added to.
+     */
+    virtual void addToList(std::list<Arg *> &argList) const;
+
+    virtual bool hasLabel() const { return false; }
+};
+
+template <class T>
+UnlabeledMultiArg<T>::UnlabeledMultiArg(const std::string &name,
+                                        const std::string &desc, bool req,
+                                        const std::string &typeDesc,
+                                        bool ignoreable, Visitor *v)
+    : MultiArg<T>("", name, desc, req, typeDesc, v) {
+    _ignoreable = ignoreable;
+    OptionalUnlabeledTracker::check(true, toString());
+}
+
+template <class T>
+UnlabeledMultiArg<T>::UnlabeledMultiArg(const std::string &name,
+                                        const std::string &desc, bool req,
+                                        const std::string &typeDesc,
+                                        ArgContainer &parser, bool ignoreable,
+                                        Visitor *v)
+    : MultiArg<T>("", name, desc, req, typeDesc, v) {
+    _ignoreable = ignoreable;
+    OptionalUnlabeledTracker::check(true, toString());
+    parser.add(this);
+}
+
+template <class T>
+UnlabeledMultiArg<T>::UnlabeledMultiArg(const std::string &name,
+                                        const std::string &desc, bool req,
+                                        Constraint<T> *constraint,
+                                        bool ignoreable, Visitor *v)
+    : MultiArg<T>("", name, desc, req, constraint, v) {
+    _ignoreable = ignoreable;
+    OptionalUnlabeledTracker::check(true, toString());
+}
+
+template <class T>
+UnlabeledMultiArg<T>::UnlabeledMultiArg(const std::string &name,
+                                        const std::string &desc, bool req,
+                                        Constraint<T> *constraint,
+                                        ArgContainer &parser, bool ignoreable,
+                                        Visitor *v)
+    : MultiArg<T>("", name, desc, req, constraint, v) {
+    _ignoreable = ignoreable;
+    OptionalUnlabeledTracker::check(true, toString());
+    parser.add(this);
+}
+
+template <class T>
+bool UnlabeledMultiArg<T>::processArg(int *i, std::vector<std::string> &args) {
+    if (_hasBlanks(args[*i])) return false;
+
+    // never ignore an unlabeled multi arg
+
+    // always take the first value, regardless of the start string
+    _extractValue(args[(*i)]);
+
+    /*
+    // continue taking args until we hit the end or a start string
+    while ( (unsigned int)(*i)+1 < args.size() &&
+            args[(*i)+1].find_first_of( Arg::flagStartString() ) != 0 &&
+            args[(*i)+1].find_first_of( Arg::nameStartString() ) != 0 )
+        _extractValue( args[++(*i)] );
+    */
+
+    _alreadySet = true;
+    _setBy = args[*i];
+
+    return true;
+}
+
+template <class T>
+bool UnlabeledMultiArg<T>::operator==(const Arg &a) const {
+    if (_name == a.getName() || _description == a.getDescription())
+        return true;
+    else
+        return false;
+}
+
+template <class T>
+void UnlabeledMultiArg<T>::addToList(std::list<Arg *> &argList) const {
+    argList.push_back(const_cast<Arg *>(static_cast<const Arg *const>(this)));
+}
+}  // namespace TCLAP
+
+#endif  // TCLAP_UNLABELED_MULTI_ARG_H

--- a/lib/tclap/UnlabeledValueArg.h
+++ b/lib/tclap/UnlabeledValueArg.h
@@ -1,0 +1,285 @@
+// -*- Mode: c++; c-basic-offset: 4; tab-width: 4; -*-
+
+/******************************************************************************
+ *
+ *  file:  UnlabeledValueArg.h
+ *
+ *  Copyright (c) 2003, Michael E. Smoot .
+ *  Copyright (c) 2004, Michael E. Smoot, Daniel Aarno.
+ *  Copyright (c) 2017, Google LLC
+ *  All rights reserved.
+ *
+ *  See the file COPYING in the top directory of this distribution for
+ *  more information.
+ *
+ *  THE SOFTWARE IS PROVIDED _AS IS_, WITHOUT WARRANTY OF ANY KIND, EXPRESS
+ *  OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ *  FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL
+ *  THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ *  LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+ *  FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
+ *  DEALINGS IN THE SOFTWARE.
+ *
+ *****************************************************************************/
+
+#ifndef TCLAP_UNLABELED_VALUE_ARG_H
+#define TCLAP_UNLABELED_VALUE_ARG_H
+
+#include <tclap/OptionalUnlabeledTracker.h>
+#include <tclap/ValueArg.h>
+
+#include <list>
+#include <string>
+#include <vector>
+
+namespace TCLAP {
+
+/**
+ * The basic unlabeled argument that parses a value.
+ * This is a template class, which means the type T defines the type
+ * that a given object will attempt to parse when an UnlabeledValueArg
+ * is reached in the list of args that the CmdLine iterates over.
+ */
+template <class T>
+class UnlabeledValueArg : public ValueArg<T> {
+    // If compiler has two stage name lookup (as gcc >= 3.4 does)
+    // this is required to prevent undef. symbols
+    using ValueArg<T>::_ignoreable;
+    using ValueArg<T>::_hasBlanks;
+    using ValueArg<T>::_extractValue;
+    using ValueArg<T>::_typeDesc;
+    using ValueArg<T>::_name;
+    using ValueArg<T>::_description;
+    using ValueArg<T>::_alreadySet;
+    using ValueArg<T>::_setBy;
+    using ValueArg<T>::toString;
+
+public:
+    /**
+     * UnlabeledValueArg constructor.
+     * \param name - A one word name for the argument.  Note that this is used
+     * for
+     * identification, not as a long flag.
+     * \param desc - A description of what the argument is for or
+     * does.
+     * \param req - Whether the argument is required on the command
+     * line.
+     * \param value - The default value assigned to this argument if it
+     * is not present on the command line.
+     * \param typeDesc - A short, human readable description of the
+     * type that this object expects.  This is used in the generation
+     * of the USAGE statement.  The goal is to be helpful to the end user
+     * of the program.
+     * \param ignoreable - Allows you to specify that this argument can be
+     * ignored if the '--' flag is set.  This defaults to false (cannot
+     * be ignored) and should  generally stay that way unless you have
+     * some special need for certain arguments to be ignored.
+     * \param v - Optional Visitor.  You should leave this blank unless
+     * you have a very good reason.
+     */
+    UnlabeledValueArg(const std::string &name, const std::string &desc,
+                      bool req, T value, const std::string &typeDesc,
+                      bool ignoreable = false, Visitor *v = NULL);
+
+    /**
+     * UnlabeledValueArg constructor.
+     * \param name - A one word name for the argument.  Note that this is used
+     * for
+     * identification, not as a long flag.
+     * \param desc - A description of what the argument is for or
+     * does.
+     * \param req - Whether the argument is required on the command
+     * line.
+     * \param value - The default value assigned to this argument if it
+     * is not present on the command line.
+     * \param typeDesc - A short, human readable description of the
+     * type that this object expects.  This is used in the generation
+     * of the USAGE statement.  The goal is to be helpful to the end user
+     * of the program.
+     * \param parser - A CmdLine parser object to add this Arg to
+     * \param ignoreable - Allows you to specify that this argument can be
+     * ignored if the '--' flag is set.  This defaults to false (cannot
+     * be ignored) and should  generally stay that way unless you have
+     * some special need for certain arguments to be ignored.
+     * \param v - Optional Visitor.  You should leave this blank unless
+     * you have a very good reason.
+     */
+    UnlabeledValueArg(const std::string &name, const std::string &desc,
+                      bool req, T value, const std::string &typeDesc,
+                      CmdLineInterface &parser, bool ignoreable = false,
+                      Visitor *v = NULL);
+
+    /**
+     * UnlabeledValueArg constructor.
+     * \param name - A one word name for the argument.  Note that this is used
+     * for
+     * identification, not as a long flag.
+     * \param desc - A description of what the argument is for or
+     * does.
+     * \param req - Whether the argument is required on the command
+     * line.
+     * \param value - The default value assigned to this argument if it
+     * is not present on the command line.
+     * \param constraint - A pointer to a Constraint object used
+     * to constrain this Arg.
+     * \param ignoreable - Allows you to specify that this argument can be
+     * ignored if the '--' flag is set.  This defaults to false (cannot
+     * be ignored) and should  generally stay that way unless you have
+     * some special need for certain arguments to be ignored.
+     * \param v - Optional Visitor.  You should leave this blank unless
+     * you have a very good reason.
+     */
+    UnlabeledValueArg(const std::string &name, const std::string &desc,
+                      bool req, T value, Constraint<T> *constraint,
+                      bool ignoreable = false, Visitor *v = NULL);
+
+    /**
+     * UnlabeledValueArg constructor.
+     * \param name - A one word name for the argument.  Note that this is used
+     * for
+     * identification, not as a long flag.
+     * \param desc - A description of what the argument is for or
+     * does.
+     * \param req - Whether the argument is required on the command
+     * line.
+     * \param value - The default value assigned to this argument if it
+     * is not present on the command line.
+     * \param constraint - A pointer to a Constraint object used
+     * to constrain this Arg.
+     * \param parser - A CmdLine parser object to add this Arg to
+     * \param ignoreable - Allows you to specify that this argument can be
+     * ignored if the '--' flag is set.  This defaults to false (cannot
+     * be ignored) and should  generally stay that way unless you have
+     * some special need for certain arguments to be ignored.
+     * \param v - Optional Visitor.  You should leave this blank unless
+     * you have a very good reason.
+     */
+    UnlabeledValueArg(const std::string &name, const std::string &desc,
+                      bool req, T value, Constraint<T> *constraint,
+                      CmdLineInterface &parser, bool ignoreable = false,
+                      Visitor *v = NULL);
+
+    /**
+     * Handles the processing of the argument.
+     * This re-implements the Arg version of this method to set the
+     * _value of the argument appropriately.  Handling specific to
+     * unlabeled arguments.
+     * \param i - Pointer the the current argument in the list.
+     * \param args - Mutable list of strings.
+     */
+    virtual bool processArg(int *i, std::vector<std::string> &args);
+
+    /**
+     * Overrides shortID for specific behavior.
+     */
+    virtual std::string shortID(const std::string &) const {
+        return Arg::getName();
+    }
+
+    /**
+     * Overrides longID for specific behavior.
+     */
+    virtual std::string longID(const std::string &) const {
+        return Arg::getName() + " <" + _typeDesc + ">";
+    }
+
+    /**
+     * Overrides operator== for specific behavior.
+     */
+    virtual bool operator==(const Arg &a) const;
+
+    /**
+     * Instead of pushing to the front of list, push to the back.
+     * \param argList - The list to add this to.
+     */
+    virtual void addToList(std::list<Arg *> &argList) const;
+
+    virtual bool hasLabel() const { return false; }
+};
+
+/**
+ * Constructor implementation.
+ */
+template <class T>
+UnlabeledValueArg<T>::UnlabeledValueArg(const std::string &name,
+                                        const std::string &desc, bool req,
+                                        T val, const std::string &typeDesc,
+                                        bool ignoreable, Visitor *v)
+    : ValueArg<T>("", name, desc, req, val, typeDesc, v) {
+    _ignoreable = ignoreable;
+
+    OptionalUnlabeledTracker::check(req, toString());
+}
+
+template <class T>
+UnlabeledValueArg<T>::UnlabeledValueArg(const std::string &name,
+                                        const std::string &desc, bool req,
+                                        T val, const std::string &typeDesc,
+                                        CmdLineInterface &parser,
+                                        bool ignoreable, Visitor *v)
+    : ValueArg<T>("", name, desc, req, val, typeDesc, v) {
+    _ignoreable = ignoreable;
+    OptionalUnlabeledTracker::check(req, toString());
+    parser.add(this);
+}
+
+/**
+ * Constructor implementation.
+ */
+template <class T>
+UnlabeledValueArg<T>::UnlabeledValueArg(const std::string &name,
+                                        const std::string &desc, bool req,
+                                        T val, Constraint<T> *constraint,
+                                        bool ignoreable, Visitor *v)
+    : ValueArg<T>("", name, desc, req, val, constraint, v) {
+    _ignoreable = ignoreable;
+    OptionalUnlabeledTracker::check(req, toString());
+}
+
+template <class T>
+UnlabeledValueArg<T>::UnlabeledValueArg(const std::string &name,
+                                        const std::string &desc, bool req,
+                                        T val, Constraint<T> *constraint,
+                                        CmdLineInterface &parser,
+                                        bool ignoreable, Visitor *v)
+    : ValueArg<T>("", name, desc, req, val, constraint, v) {
+    _ignoreable = ignoreable;
+    OptionalUnlabeledTracker::check(req, toString());
+    parser.add(this);
+}
+
+/**
+ * Implementation of processArg().
+ */
+template <class T>
+bool UnlabeledValueArg<T>::processArg(int *i, std::vector<std::string> &args) {
+    if (_alreadySet) return false;
+
+    if (_hasBlanks(args[*i])) return false;
+
+    // never ignore an unlabeled arg
+
+    _extractValue(args[*i]);
+    _alreadySet = true;
+    _setBy = args[*i];
+    return true;
+}
+
+/**
+ * Overriding operator== for specific behavior.
+ */
+template <class T>
+bool UnlabeledValueArg<T>::operator==(const Arg &a) const {
+    if (_name == a.getName() || _description == a.getDescription())
+        return true;
+    else
+        return false;
+}
+
+template <class T>
+void UnlabeledValueArg<T>::addToList(std::list<Arg *> &argList) const {
+    argList.push_back(const_cast<Arg *>(static_cast<const Arg *const>(this)));
+}
+}  // namespace TCLAP
+
+#endif  // TCLAP_UNLABELED_VALUE_ARG_H

--- a/lib/tclap/ValueArg.h
+++ b/lib/tclap/ValueArg.h
@@ -1,0 +1,365 @@
+// -*- Mode: c++; c-basic-offset: 4; tab-width: 4; -*-
+
+/******************************************************************************
+ *
+ *  file:  ValueArg.h
+ *
+ *  Copyright (c) 2003, Michael E. Smoot .
+ *  Copyright (c) 2004, Michael E. Smoot, Daniel Aarno.
+ *  Copyright (c) 2017, Google LLC
+ *  All rights reserved.
+ *
+ *  See the file COPYING in the top directory of this distribution for
+ *  more information.
+ *
+ *  THE SOFTWARE IS PROVIDED _AS IS_, WITHOUT WARRANTY OF ANY KIND, EXPRESS
+ *  OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ *  FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL
+ *  THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ *  LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+ *  FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
+ *  DEALINGS IN THE SOFTWARE.
+ *
+ *****************************************************************************/
+
+#ifndef TCLAP_VALUE_ARG_H
+#define TCLAP_VALUE_ARG_H
+
+#include <tclap/Arg.h>
+#include <tclap/Constraint.h>
+
+#include <string>
+#include <vector>
+
+namespace TCLAP {
+
+/**
+ * The basic labeled argument that parses a value.
+ * This is a template class, which means the type T defines the type
+ * that a given object will attempt to parse when the flag/name is matched
+ * on the command line.  While there is nothing stopping you from creating
+ * an unflagged ValueArg, it is unwise and would cause significant problems.
+ * Instead use an UnlabeledValueArg.
+ */
+template <class T>
+class ValueArg : public Arg {
+protected:
+    /**
+     * The value parsed from the command line.
+     * Can be of any type, as long as the >> operator for the type
+     * is defined.
+     */
+    T _value;
+
+    /**
+     * Used to support the reset() method so that ValueArg can be
+     * reset to their constructed value.
+     */
+    T _default;
+
+    /**
+     * A human readable description of the type to be parsed.
+     * This is a hack, plain and simple.  Ideally we would use RTTI to
+     * return the name of type T, but until there is some sort of
+     * consistent support for human readable names, we are left to our
+     * own devices.
+     */
+    std::string _typeDesc;
+
+    /**
+     * A Constraint this Arg must conform to.
+     */
+    Constraint<T> *_constraint;
+
+    /**
+     * Extracts the value from the string.
+     * Attempts to parse string as type T, if this fails an exception
+     * is thrown.
+     * \param val - value to be parsed.
+     */
+    void _extractValue(const std::string &val);
+
+public:
+    /**
+     * Labeled ValueArg constructor.
+     * You could conceivably call this constructor with a blank flag,
+     * but that would make you a bad person.  It would also cause
+     * an exception to be thrown.   If you want an unlabeled argument,
+     * use the other constructor.
+     * \param flag - The one character flag that identifies this
+     * argument on the command line.
+     * \param name - A one word name for the argument.  Can be
+     * used as a long flag on the command line.
+     * \param desc - A description of what the argument is for or
+     * does.
+     * \param req - Whether the argument is required on the command
+     * line.
+     * \param value - The default value assigned to this argument if it
+     * is not present on the command line.
+     * \param typeDesc - A short, human readable description of the
+     * type that this object expects.  This is used in the generation
+     * of the USAGE statement.  The goal is to be helpful to the end user
+     * of the program.
+     * \param v - An optional visitor.  You probably should not
+     * use this unless you have a very good reason.
+     */
+    ValueArg(const std::string &flag, const std::string &name,
+             const std::string &desc, bool req, T value,
+             const std::string &typeDesc, Visitor *v = NULL);
+
+    /**
+     * Labeled ValueArg constructor.
+     * You could conceivably call this constructor with a blank flag,
+     * but that would make you a bad person.  It would also cause
+     * an exception to be thrown.   If you want an unlabeled argument,
+     * use the other constructor.
+     * \param flag - The one character flag that identifies this
+     * argument on the command line.
+     * \param name - A one word name for the argument.  Can be
+     * used as a long flag on the command line.
+     * \param desc - A description of what the argument is for or
+     * does.
+     * \param req - Whether the argument is required on the command
+     * line.
+     * \param value - The default value assigned to this argument if it
+     * is not present on the command line.
+     * \param typeDesc - A short, human readable description of the
+     * type that this object expects.  This is used in the generation
+     * of the USAGE statement.  The goal is to be helpful to the end user
+     * of the program.
+     * \param parser - A CmdLine parser object to add this Arg to
+     * \param v - An optional visitor.  You probably should not
+     * use this unless you have a very good reason.
+     */
+    ValueArg(const std::string &flag, const std::string &name,
+             const std::string &desc, bool req, T value,
+             const std::string &typeDesc, ArgContainer &parser,
+             Visitor *v = NULL);
+
+    /**
+     * Labeled ValueArg constructor.
+     * You could conceivably call this constructor with a blank flag,
+     * but that would make you a bad person.  It would also cause
+     * an exception to be thrown.   If you want an unlabeled argument,
+     * use the other constructor.
+     * \param flag - The one character flag that identifies this
+     * argument on the command line.
+     * \param name - A one word name for the argument.  Can be
+     * used as a long flag on the command line.
+     * \param desc - A description of what the argument is for or
+     * does.
+     * \param req - Whether the argument is required on the command
+     * line.
+     * \param value - The default value assigned to this argument if it
+     * is not present on the command line.
+     * \param constraint - A pointer to a Constraint object used
+     * to constrain this Arg.
+     * \param parser - A CmdLine parser object to add this Arg to.
+     * \param v - An optional visitor.  You probably should not
+     * use this unless you have a very good reason.
+     */
+    ValueArg(const std::string &flag, const std::string &name,
+             const std::string &desc, bool req, T value,
+             Constraint<T> *constraint, ArgContainer &parser,
+             Visitor *v = NULL);
+
+    /**
+     * Labeled ValueArg constructor.
+     * You could conceivably call this constructor with a blank flag,
+     * but that would make you a bad person.  It would also cause
+     * an exception to be thrown.   If you want an unlabeled argument,
+     * use the other constructor.
+     * \param flag - The one character flag that identifies this
+     * argument on the command line.
+     * \param name - A one word name for the argument.  Can be
+     * used as a long flag on the command line.
+     * \param desc - A description of what the argument is for or
+     * does.
+     * \param req - Whether the argument is required on the command
+     * line.
+     * \param value - The default value assigned to this argument if it
+     * is not present on the command line.
+     * \param constraint - A pointer to a Constraint object used
+     * to constrain this Arg.
+     * \param v - An optional visitor.  You probably should not
+     * use this unless you have a very good reason.
+     */
+    ValueArg(const std::string &flag, const std::string &name,
+             const std::string &desc, bool req, T value,
+             Constraint<T> *constraint, Visitor *v = NULL);
+
+    /**
+     * Handles the processing of the argument.
+     * This re-implements the Arg version of this method to set the
+     * _value of the argument appropriately.  It knows the difference
+     * between labeled and unlabeled.
+     * \param i - Pointer the the current argument in the list.
+     * \param args - Mutable list of strings. Passed
+     * in from main().
+     */
+    virtual bool processArg(int *i, std::vector<std::string> &args);
+
+    /**
+     * Returns the value of the argument.
+     */
+    const T &getValue() const { return _value; }
+
+    /**
+     * A ValueArg can be used as as its value type (T) This is the
+     * same as calling getValue()
+     */
+    operator const T &() const { return getValue(); }
+
+    /**
+     * Specialization of shortID.
+     * \param val - value to be used.
+     */
+    virtual std::string shortID(const std::string &val = "val") const;
+
+    /**
+     * Specialization of longID.
+     * \param val - value to be used.
+     */
+    virtual std::string longID(const std::string &val = "val") const;
+
+    virtual void reset();
+
+private:
+    /**
+     * Prevent accidental copying
+     */
+    ValueArg<T>(const ValueArg<T> &rhs);
+    ValueArg<T> &operator=(const ValueArg<T> &rhs);
+};
+
+/**
+ * Constructor implementation.
+ */
+template <class T>
+ValueArg<T>::ValueArg(const std::string &flag, const std::string &name,
+                      const std::string &desc, bool req, T val,
+                      const std::string &typeDesc, Visitor *v)
+    : Arg(flag, name, desc, req, true, v),
+      _value(val),
+      _default(val),
+      _typeDesc(typeDesc),
+      _constraint(NULL) {}
+
+template <class T>
+ValueArg<T>::ValueArg(const std::string &flag, const std::string &name,
+                      const std::string &desc, bool req, T val,
+                      const std::string &typeDesc, ArgContainer &parser,
+                      Visitor *v)
+    : Arg(flag, name, desc, req, true, v),
+      _value(val),
+      _default(val),
+      _typeDesc(typeDesc),
+      _constraint(NULL) {
+    parser.add(this);
+}
+
+template <class T>
+ValueArg<T>::ValueArg(const std::string &flag, const std::string &name,
+                      const std::string &desc, bool req, T val,
+                      Constraint<T> *constraint, Visitor *v)
+    : Arg(flag, name, desc, req, true, v),
+      _value(val),
+      _default(val),
+      _typeDesc(Constraint<T>::shortID(constraint)),
+      _constraint(constraint) {}
+
+template <class T>
+ValueArg<T>::ValueArg(const std::string &flag, const std::string &name,
+                      const std::string &desc, bool req, T val,
+                      Constraint<T> *constraint, ArgContainer &parser,
+                      Visitor *v)
+    : Arg(flag, name, desc, req, true, v),
+      _value(val),
+      _default(val),
+      _typeDesc(Constraint<T>::shortID(constraint)),
+      _constraint(constraint) {
+    parser.add(this);
+}
+
+/**
+ * Implementation of processArg().
+ */
+template <class T>
+bool ValueArg<T>::processArg(int *i, std::vector<std::string> &args) {
+    if (_hasBlanks(args[*i])) return false;
+
+    std::string flag = args[*i];
+
+    std::string value = "";
+    trimFlag(flag, value);
+
+    if (argMatches(flag)) {
+        if (_alreadySet) {
+            throw(CmdLineParseException("Argument already set!", toString()));
+        }
+
+        if (Arg::delimiter() != ' ' && value == "")
+            throw(ArgParseException(
+                "Couldn't find delimiter for this argument!", toString()));
+
+        if (value == "") {
+            (*i)++;
+            if (static_cast<unsigned int>(*i) < args.size())
+                _extractValue(args[*i]);
+            else
+                throw(ArgParseException("Missing a value for this argument!",
+                                        toString()));
+        } else {
+            _extractValue(value);
+        }
+
+        _alreadySet = true;
+        _setBy = flag;
+        _checkWithVisitor();
+        return true;
+    } else {
+        return false;
+    }
+}
+
+/**
+ * Implementation of shortID.
+ */
+template <class T>
+std::string ValueArg<T>::shortID(const std::string &) const {
+    return Arg::shortID("<" + _typeDesc + ">");
+}
+
+/**
+ * Implementation of longID.
+ */
+template <class T>
+std::string ValueArg<T>::longID(const std::string &) const {
+    return Arg::longID("<" + _typeDesc + ">");
+}
+
+template <class T>
+void ValueArg<T>::_extractValue(const std::string &val) {
+    try {
+        ExtractValue(_value, val, typename ArgTraits<T>::ValueCategory());
+    } catch (ArgParseException &e) {
+        throw ArgParseException(e.error(), toString());
+    }
+
+    if (_constraint != NULL)
+        if (!_constraint->check(_value))
+            throw(CmdLineParseException("Value '" + val +
+                                            +"' does not meet constraint: " +
+                                            _constraint->description(),
+                                        toString()));
+}
+
+template <class T>
+void ValueArg<T>::reset() {
+    Arg::reset();
+    _value = _default;
+}
+
+}  // namespace TCLAP
+
+#endif  // TCLAP_VALUE_ARG_H

--- a/lib/tclap/ValuesConstraint.h
+++ b/lib/tclap/ValuesConstraint.h
@@ -1,0 +1,115 @@
+// -*- Mode: c++; c-basic-offset: 4; tab-width: 4; -*-
+
+/******************************************************************************
+ *
+ *  file:  ValuesConstraint.h
+ *
+ *  Copyright (c) 2005, Michael E. Smoot
+ *  Copyright (c) 2017, Google LLC
+ *  All rights reserved.
+ *
+ *  See the file COPYING in the top directory of this distribution for
+ *  more information.
+ *
+ *  THE SOFTWARE IS PROVIDED _AS IS_, WITHOUT WARRANTY OF ANY KIND, EXPRESS
+ *  OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ *  FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL
+ *  THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ *  LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+ *  FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
+ *  DEALINGS IN THE SOFTWARE.
+ *
+ *****************************************************************************/
+
+#ifndef TCLAP_VALUES_CONSTRAINT_H
+#define TCLAP_VALUES_CONSTRAINT_H
+
+#include <tclap/Constraint.h>
+#include <tclap/sstream.h>
+
+#include <string>
+#include <vector>
+
+namespace TCLAP {
+
+/**
+ * A Constraint that constrains the Arg to only those values specified
+ * in the constraint.
+ */
+template <class T>
+class ValuesConstraint : public Constraint<T> {
+public:
+    /**
+     * Constructor.
+     * \param allowed - vector of allowed values.
+     */
+    explicit ValuesConstraint(std::vector<T> &allowed);
+
+    /**
+     * Virtual destructor.
+     */
+    virtual ~ValuesConstraint() {}
+
+    /**
+     * Returns a description of the Constraint.
+     */
+    virtual std::string description() const;
+
+    /**
+     * Returns the short ID for the Constraint.
+     */
+    virtual std::string shortID() const;
+
+    /**
+     * The method used to verify that the value parsed from the command
+     * line meets the constraint.
+     * \param value - The value that will be checked.
+     */
+    virtual bool check(const T &value) const;
+
+protected:
+    /**
+     * The list of valid values.
+     */
+    std::vector<T> _allowed;
+
+    /**
+     * The string used to describe the allowed values of this constraint.
+     */
+    std::string _typeDesc;
+};
+
+template <class T>
+ValuesConstraint<T>::ValuesConstraint(std::vector<T> &allowed)
+    : _allowed(allowed), _typeDesc("") {
+    for (unsigned int i = 0; i < _allowed.size(); i++) {
+        std::ostringstream os;
+        os << _allowed[i];
+
+        std::string temp(os.str());
+
+        if (i > 0) _typeDesc += "|";
+        _typeDesc += temp;
+    }
+}
+
+template <class T>
+bool ValuesConstraint<T>::check(const T &val) const {
+    if (std::find(_allowed.begin(), _allowed.end(), val) == _allowed.end())
+        return false;
+    else
+        return true;
+}
+
+template <class T>
+std::string ValuesConstraint<T>::shortID() const {
+    return _typeDesc;
+}
+
+template <class T>
+std::string ValuesConstraint<T>::description() const {
+    return _typeDesc;
+}
+
+}  // namespace TCLAP
+#endif  // TCLAP_VALUES_CONSTRAINT_H

--- a/lib/tclap/VersionVisitor.h
+++ b/lib/tclap/VersionVisitor.h
@@ -1,0 +1,75 @@
+// -*- Mode: c++; c-basic-offset: 4; tab-width: 4; -*-
+
+/******************************************************************************
+ *
+ *  file:  VersionVisitor.h
+ *
+ *  Copyright (c) 2003, Michael E. Smoot .
+ *  All rights reserved.
+ *
+ *  See the file COPYING in the top directory of this distribution for
+ *  more information.
+ *
+ *  THE SOFTWARE IS PROVIDED _AS IS_, WITHOUT WARRANTY OF ANY KIND, EXPRESS
+ *  OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ *  FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL
+ *  THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ *  LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+ *  FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
+ *  DEALINGS IN THE SOFTWARE.
+ *
+ *****************************************************************************/
+
+#ifndef TCLAP_VERSION_VISITOR_H
+#define TCLAP_VERSION_VISITOR_H
+
+#include <tclap/CmdLineInterface.h>
+#include <tclap/CmdLineOutput.h>
+#include <tclap/Visitor.h>
+
+namespace TCLAP {
+
+/**
+ * A Visitor that will call the version method of the given CmdLineOutput
+ * for the specified CmdLine object and then exit.
+ */
+class VersionVisitor : public Visitor {
+private:
+    /**
+     * Prevent accidental copying
+     */
+    VersionVisitor(const VersionVisitor &rhs);
+    VersionVisitor &operator=(const VersionVisitor &rhs);
+
+protected:
+    /**
+     * The CmdLine of interest.
+     */
+    CmdLineInterface *_cmd;
+
+    /**
+     * The output object.
+     */
+    CmdLineOutput **_out;
+
+public:
+    /**
+     * Constructor.
+     * \param cmd - The CmdLine the output is generated for.
+     * \param out - The type of output.
+     */
+    VersionVisitor(CmdLineInterface *cmd, CmdLineOutput **out)
+        : Visitor(), _cmd(cmd), _out(out) {}
+
+    /**
+     * Calls the version method of the output object using the
+     * specified CmdLine.
+     */
+    void visit() {
+        (*_out)->version(*_cmd);
+        throw ExitException(0);
+    }
+};
+}  // namespace TCLAP
+
+#endif  // TCLAP_VERSION_VISITOR_H

--- a/lib/tclap/Visitor.h
+++ b/lib/tclap/Visitor.h
@@ -1,0 +1,52 @@
+// -*- Mode: c++; c-basic-offset: 4; tab-width: 4; -*-
+
+/******************************************************************************
+ *
+ *  file:  Visitor.h
+ *
+ *  Copyright (c) 2003, Michael E. Smoot .
+ *  Copyright (c) 2017, Google LLC
+ *  All rights reserved.
+ *
+ *  See the file COPYING in the top directory of this distribution for
+ *  more information.
+ *
+ *  THE SOFTWARE IS PROVIDED _AS IS_, WITHOUT WARRANTY OF ANY KIND, EXPRESS
+ *  OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ *  FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL
+ *  THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ *  LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+ *  FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
+ *  DEALINGS IN THE SOFTWARE.
+ *
+ *****************************************************************************/
+
+#ifndef TCLAP_VISITOR_H
+#define TCLAP_VISITOR_H
+
+namespace TCLAP {
+
+/**
+ * A base class that defines the interface for visitors.
+ */
+class Visitor {
+public:
+    /**
+     * Constructor. Does nothing.
+     */
+    Visitor() {}
+
+    /**
+     * Destructor. Does nothing.
+     */
+    virtual ~Visitor() {}
+
+    /**
+     * This method (to implemented by children) will be
+     * called when the visitor is visited.
+     */
+    virtual void visit() = 0;
+};
+}  // namespace TCLAP
+
+#endif  // TCLAP_VISITOR_H

--- a/lib/tclap/sstream.h
+++ b/lib/tclap/sstream.h
@@ -1,0 +1,50 @@
+// -*- Mode: c++; c-basic-offset: 4; tab-width: 4; -*-
+
+/******************************************************************************
+ *
+ *  file:  sstream.h
+ *
+ *  Copyright (c) 2003, Michael E. Smoot .
+ *  Copyright (c) 2004, Michael E. Smoot, Daniel Aarno .
+ *  Copyright (c) 2017 Google Inc.
+ *  All rights reserved.
+ *
+ *  See the file COPYING in the top directory of this distribution for
+ *  more information.
+ *
+ *  THE SOFTWARE IS PROVIDED _AS IS_, WITHOUT WARRANTY OF ANY KIND, EXPRESS
+ *  OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ *  FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL
+ *  THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ *  LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+ *  FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
+ *  DEALINGS IN THE SOFTWARE.
+ *
+ *****************************************************************************/
+
+#ifndef TCLAP_SSTREAM_H
+#define TCLAP_SSTREAM_H
+
+#if !defined(TCLAP_HAVE_STRSTREAM)
+// Assume sstream is available if strstream is not specified
+// (https://sourceforge.net/p/tclap/bugs/23/)
+#define TCLAP_HAVE_SSTREAM
+#endif
+
+#if defined(TCLAP_HAVE_SSTREAM)
+#include <sstream>
+namespace TCLAP {
+typedef std::istringstream istringstream;
+typedef std::ostringstream ostringstream;
+}  // namespace TCLAP
+#elif defined(TCLAP_HAVE_STRSTREAM)
+#include <strstream>
+namespace TCLAP {
+typedef std::istrstream istringstream;
+typedef std::ostrstream ostringstream;
+}  // namespace TCLAP
+#else
+#error "Need a stringstream (sstream or strstream) to compile!"
+#endif
+
+#endif  // TCLAP_SSTREAM_H

--- a/simulation/src/Demo.cpp
+++ b/simulation/src/Demo.cpp
@@ -256,7 +256,7 @@ void Demo::demoLoop(){
 				 break;
 			 }
 		 }
- }
+ }  // end if visualization is active
 
  // Case 2: the visualization is deactivated. It can be activated/deactivated by giving the right argument to the function (\ref param)
  else{

--- a/simulation/src/main.cpp
+++ b/simulation/src/main.cpp
@@ -16,7 +16,7 @@
 void parse_argument(char* argv[], int i, config::sConfig& cfg);
 void load_config(std::string filename, config::sConfig& cfg);
 void help();
-void print_help_and_exit(TCLAP::CmdLineInterface& cmd);
+int print_help_and_exit(TCLAP::CmdLineInterface& cmd);
 
 using namespace TCLAP;
 
@@ -73,10 +73,6 @@ int main(int argc, char* argv[])
 	ValueArg<float>       v_height_arg("", "v_height", "Height of the v shape in v_terrain in robot body lengths", false, 3.5, "HEIGHT float 3.5");
 	ValueArg<float>       angle_arg("", "v_half_angle", "Half angle of the v shape in v_terrain in robot body lengths. When angle > 0, width is not taken into account", false, 50/RAD_TO_DEG, "DEG float 50/RAD_TO_DEG");
 
-	// arg_list.emplace_back(terrain_type_arg);
-
-	// std::cout << arg_list.front() << std::endl;
-	std::cout << "LAMA" << std::endl;
 	// Create Simulation Parameters
 	ValueArg<float>       gravity_arg("g", "gravity", "Magnitude of gravity in simulation in m/s^2", false, 0.0, "ACCEL float 0.0");
 	ValueArg<float>       robot_distance_arg("", "robot_distance", "Distance between the creation of two successive robots in s", false, 3.5, "BL float 3.5");
@@ -160,7 +156,7 @@ int main(int argc, char* argv[])
 	// std::cout << "Terrain type: A " << terrain_type_arg.getValue() << std::endl;
 
 	if (help_arg.getValue()){
-		print_help_and_exit(cmd);
+		return print_help_and_exit(cmd);
 	}
 
 	// Set all the config parameters according to the command line parsing
@@ -213,26 +209,14 @@ int main(int argc, char* argv[])
    return 0;
 }
 
-void print_help_and_exit(CmdLineInterface& cmd)
+int print_help_and_exit(CmdLineInterface& cmd)
 {
 	std::cout << "Launch a simulation for the ant bridge formation" << std::endl;
 	std::cout << "Usage: ./ArmyAntSim [parameters]" << std::endl;
 	std::cout << "Parameters:" << std::endl;
-	std::list<Arg*> arg_list = cmd.getArgList();
+	std::list<Arg*> arg_list = cmd.getArgList(); arg_list.reverse();
+	std::vector<std::string> help_vec;
 	for (Arg* arg : arg_list) {
-		std::string example = " -r <DIST>      Length of the runway relative to the robot body length (--runway, float, default = 7)";
-		std::cout << "-------------------" << std::endl;
-		// Look at the long ID
-		//
-
-
-		// // Get the Short Id
-		// std::string short_id = arg->shortID();
-
-		// // Get the long id and extract the other flag if there is one
-		// std::string long_id = arg->longID();
-		// std::string extra_id = "";
-
 		// This part gets the argument flags Ex: -h and --help
 		std::string line;
 		std::vector<std::string> vec;
@@ -252,19 +236,13 @@ void print_help_and_exit(CmdLineInterface& cmd)
 			flags[1] = flags[1].substr(1,flags[1].size()-2);
 		}
 
-		std::cout << "toString vector: " << std::endl;
-		for (std::string str : flags) {
-			std::cout << str << std::endl;
-		}
-		std::cout << "toString end" << std::endl;
-
 		// This part gets the human-readable INPUT, type, default
 		// std::string line2;
 		std::string short_ID = arg->shortID();
 		if (short_ID.find('<') != std::string::npos) {
 			// So we know this is a value argument
 			std::string info_string = short_ID.substr(short_ID.find("<")+1, short_ID.find(">")-short_ID.find("<")-1);
-			std::cout << "info_string: " << info_string << std::endl;
+			// std::cout << "info_string: " << info_string << std::endl;
 
 			// Split the info string into its components
 			std::vector<std::string> vec2;
@@ -272,11 +250,6 @@ void print_help_and_exit(CmdLineInterface& cmd)
 			while(std::getline(ss,line,' ')) {
 				vec2.push_back(line);
 			}
-			std::cout << "info_string vector: " << std::endl;
-			for (std::string str : vec2) {
-				std::cout << str << std::endl;
-			}
-			std::cout << "info_string vector end" << std::endl;
 
 			std::string human_readable = vec2[0];
 			std::string arg_type = vec2[1];
@@ -287,69 +260,70 @@ void print_help_and_exit(CmdLineInterface& cmd)
 			if (flags.size() == 2) { second_arg = flags[1] + ", "; }
 
 			// Build the help message for this argument
-			std::string arg_output = " " + flags[0] + " <" + human_readable + ">      " + arg->getDescription() + " (" + second_arg + arg_type + ", default = " + arg_default + ")";
+			std::string help_output = flags[0] + " <" + human_readable + ">" + arg->getDescription() + " (" + second_arg + arg_type + ", default = " + arg_default + ")";
 
-			std::cout << arg_output << std::endl;
-
-			// std::string example = " -r <DIST>      Length of the runway relative to the robot body length (--runway, float, default = 7)";
+			// Shove it in with the others
+			help_vec.emplace_back(help_output);
 		}
 		else {
 			// We'll do something else here
+
 		}
 
-		// std::vector<std::string> vec2;
-		// std::stringstream ss2(arg->longID());
-		// while(std::getline(ss2,line,' ')) {
-		// 	vec.push_back(line);
-		// }
-		// std::cout << "longID vector: " << std::endl;
-		// for (std::string str : vec) {
-		// 	std::cout << str << std::endl;
-		// }
-		// std::cout << "longID end" << std::endl;
+		// std::cout << "getFlag: " << arg->getFlag() << std::endl;
+		// std::cout << "getName: " << arg->getName() << std::endl;
+		// std::cout << "getDescription: " << arg->getDescription() << std::endl;
+		// std::cout << "isRequired: " << arg->isRequired() << std::endl;
+		// std::cout << "toString: " << arg->toString() << std::endl;
+		// std::cout << "Short ID: " << arg->shortID() << std::endl;
+		// std::cout << "Long ID: " << arg->longID() << std::endl;
+		// std::cout << "setBy: " << arg->setBy() << std::endl;
+		// // std::cout << arg->getValue() << std::endl;
+		// std::cout << "flagStartString: " << arg->flagStartString() << std::endl;
+		// std::cout << "nameStartString: " << arg->nameStartString() << std::endl;
+	} // end for (Arg* arg : arg_list)
 
-		// Throw in the description
-		// std::string id_description = short_id + " " + arg->getDescription();
-
-		//
-
-		std::cout << "getFlag: " << arg->getFlag() << std::endl;
-		std::cout << "getName: " << arg->getName() << std::endl;
-		std::cout << "getDescription: " << arg->getDescription() << std::endl;
-		std::cout << "isRequired: " << arg->isRequired() << std::endl;
-		std::cout << "toString: " << arg->toString() << std::endl;
-		std::cout << "Short ID: " << arg->shortID() << std::endl;
-		std::cout << "Long ID: " << arg->longID() << std::endl;
-		std::cout << "setBy: " << arg->setBy() << std::endl;
-		// std::cout << arg->getValue() << std::endl;
-		std::cout << "flagStartString: " << arg->flagStartString() << std::endl;
-		std::cout << "nameStartString: " << arg->nameStartString() << std::endl;
-
-		// // start the info string with 14 empty spaces
-		// std::string info_str(14, ' ');
-
-		// // Add in the argument flag if there is one
-		// if (arg->getFlag().size() >0) {
-		// 	info_str.replace(2, 1, "-"+arg->getFlag());
-		// }
-
-		// // Add in the
-
-
-
-		// std::cout << "	-r DIST		Sets the length of the v-terrain runaway relatively to the robot body length (--terrain_runaway, default = 7) " << std::endl;
-		// std::cout << "  -cp PATH    Give the path of the configuration file (--configuration_path) \n" << std::endl;
-		// std::cout << " " + arg->longID() + "  " + arg->getDescription()
-
-		// std::cou
-
-	// std::cout << "	-cp PATH    Give the path of the configuration file (--configuration_path) \n" << std::endl;
-
+	// Find the length of the longest intro for all the arguments. Intro includes --flag <HUMAN-READABLE-INPUT>
+	int longest_intro = 0;
+	// std::cout << "longest_intro: " << longest_intro << std::endl;
+	for (std::string help_output : help_vec) {
+		if (help_output.find(">") > longest_intro) {
+			longest_intro = help_output.find(">");
+			// std::cout << "longest_intro: " << longest_intro << std::endl;
+		}
+		// std::cout << help_output << std::endl;
 	}
 
+	// Left align all of the descriptions according to the longest intro
+	for (std::string help_output : help_vec) {
+		// split the string into intro and description
+		std::vector<std::string> help_components;
+		std::stringstream ss(help_output);
+		std::string line;
+		while(std::getline(ss,line,'>')) {
+			help_components.push_back(line);
+		}
+
+		std::string intro = help_components[0] + ">";
+		std::string description = help_components[1];
+
+		// Check if this is a key argument and print extra message if relevant
+		if (intro == "--configuration_path <PATH>") {std::cout << "\n  Config: " << std::endl;}
+		else if (intro == "-y <TERRAIN>") {std::cout << "\n  Terrain:" << std::endl;}
+		else if (intro == "--robot_distance <BL>") {std::cout << "\n  Simulation:" << std::endl;}
+		else if (intro == "--body_length <METERS>") {std::cout << "\n  Robot:" << std::endl;}
+		else if (intro == "--window_x <PIX>") {std::cout << "\n  Window:" << std::endl;}
+		else if (intro == "--file_path <PATH>") {std::cout << "\n  File:" << std::endl;}
+		// Make the intro longer according to the longest_intro. Add an offset for nicer spacing
+		intro =  intro + std::string( longest_intro - intro.size() + 5, ' ');
+
+		// Print the argument help
+		std::cout << "    " << intro << description << std::endl;
+	}
+	std::cout << std::endl;
 
 
-
+	return 0;
 
 }
 


### PR DESCRIPTION
- refactored command line to use tclap library - this means no more manual parsing
- added tclap library to repo
- updated `CMakeLists.txt` to use C++ 17
- To add in a new arg for an existing config variable, you have to do 3 things
    1. Add the arg as a tclap arg under the appropriate section of `ValueArg`s in `main.cpp`
    2. Add `cmd.add()` for the arg in `main.cpp`
    3. Set it in the config parameters in `main.cpp`
- manually built `--help` function. In its current state, it is quite brittle, and might break if we try using anything that isn't a `ValueArg` or a `SwitchArg`