### PR TITLE
now using experimental/filesystem

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -84,4 +84,4 @@ set_target_properties(Box2D PROPERTIES
 # add executable
 add_executable(ArmyAntSim simulation/src/Config.cpp simulation/src/Demo.cpp simulation/src/helpers.cpp simulation/src/main.cpp simulation/src/RobotController.cpp simulation/src/Robot.cpp simulation/src/CliffTerrain.cpp simulation/src/BoxTerrain.cpp simulation/src/Ramp.cpp simulation/src/V2BLTerrain.cpp simulation/src/VStepper.cpp simulation/src/Vterrain.cpp simulation/src/DefaultTerrain.cpp)
 # link the Box2D library to the ArmyAntSim
-target_link_libraries(ArmyAntSim Box2D sfml-audio sfml-network sfml-window sfml-graphics sfml-system)
+target_link_libraries(ArmyAntSim Box2D sfml-audio sfml-network sfml-window sfml-graphics sfml-system stdc++fs)

--- a/simulation/src/Demo.cpp
+++ b/simulation/src/Demo.cpp
@@ -33,8 +33,8 @@
 #include <thread>
 #include <math.h>
 #include <iostream>
-#include <filesystem>
-namespace fs = std::filesystem;
+#include <experimental/filesystem>
+namespace fs = std::experimental::filesystem;
 
 bool distance_from_bottom = false;
 


### PR DESCRIPTION
- now using `#include <experimental/filesystem>` so that the code will still build on older versions of gcc. `#include <filesystem>` was not supported until gcc 8. Link to [gcc change log](https://gcc.gnu.org/gcc-8/changes.html)